### PR TITLE
Fix: affiche les heures correctements

### DIFF
--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -24,7 +24,7 @@ case class Application(id: UUID,
      } else if(period.getDays > 1) {
        s"il y a ${period.getDays} jours"
      } else if(period.getHours > 1) {
-       s"il y a ${period.getDays} heures"
+       s"il y a ${period.getHours} heures"
      } else if(period.getMinutes > 1) {
        s"il y a ${period.getMinutes} minutes"
      } else {


### PR DESCRIPTION
Il y avait un bug : (il y a 0 heures) au lieu de (il y a 3 heures) 