### PR TITLE
Simplification UI Territoire + Nettoyage du territoire courant (currentArea)

### DIFF
--- a/app/controllers/AreaController.scala
+++ b/app/controllers/AreaController.scala
@@ -42,7 +42,7 @@ class AreaController @Inject()(loginAction: LoginAction,
       } else { 
         userGroupService.byIds(request.currentUser.groupIds)
       }
-      Ok(views.html.allArea(request.currentUser, request.currentArea)(Area.all, areasWithLoginByKey, userGroups))
+      Ok(views.html.allArea(request.currentUser)(Area.all, areasWithLoginByKey, userGroups))
     }
   }
 }

--- a/app/controllers/AreaController.scala
+++ b/app/controllers/AreaController.scala
@@ -20,6 +20,7 @@ class AreaController @Inject()(loginAction: LoginAction,
                                configuration: play.api.Configuration)(implicit val webJarsUtil: WebJarsUtil, ec: ExecutionContext) extends InjectedController {
   private lazy val areasWithLoginByKey = configuration.underlying.getString("app.areasWithLoginByKey").split(",").flatMap(UUIDHelper.fromString)
 
+  @deprecated
   def change(areaId: UUID) = loginAction { implicit request =>
     if (!request.currentUser.areas.contains(areaId)) {
       eventService.warn("CHANGE_AREA_UNAUTHORIZED", s"Accès à la zone $areaId non autorisé")

--- a/app/controllers/GroupController.scala
+++ b/app/controllers/GroupController.scala
@@ -64,7 +64,7 @@ case class GroupController @Inject()(loginAction: LoginAction,
           code -> ws.url(url).get().toCompletableFuture.get().getBody
         }
         val zoneAsJson = areas.map({ case (code, name) => s"""{ "code": "$code", "name": "$name" }""" }).mkString("[", ",", "]")
-        Ok(views.html.editGroup(request.currentUser, request.currentArea)(group, groupUsers, isEmpty, zoneAsJson, Host))
+        Ok(views.html.editGroup(request.currentUser)(group, groupUsers, isEmpty, zoneAsJson, Host))
       }
     }
   }

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -35,6 +35,6 @@ class HomeController @Inject()(loginAction: LoginAction, db: Database)(implicit 
   }
 
   def help = loginAction { implicit request =>
-    Ok(views.html.help(request.currentUser, request.currentArea))
+    Ok(views.html.help(request.currentUser))
   }
 }

--- a/app/models/Answer.scala
+++ b/app/models/Answer.scala
@@ -12,7 +12,6 @@ case class Answer(id: UUID,
                   creatorUserName: String,
                   invitedUsers: Map[UUID, String],
                   visibleByHelpers: Boolean,
-                  area: UUID,
                   declareApplicationHasIrrelevant: Boolean,
                   userInfos: Option[Map[String, String]],
                   files: Option[Map[String, Long]] = Some(Map())) extends AgeModel {

--- a/app/tasks/AutoAddExpertTask.scala
+++ b/app/tasks/AutoAddExpertTask.scala
@@ -54,7 +54,6 @@ class AutoAddExpertTask @Inject()(actorSystem: ActorSystem,
           expert.nameWithQualite,
           experts,
           true,
-          application.area,
           false,
           Some(Map()))
         if (applicationService.add(application.id, answer, true)  == 1) {

--- a/app/views/CSVExport.scala.html
+++ b/app/views/CSVExport.scala.html
@@ -1,6 +1,6 @@
-@(user: User, area: Area)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(user: User)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
-@main(user, area, false)(s"Exporter mes demandes") {
+@main(user)(s"Exporter mes demandes") {
 }{
     <div class="mdl-cell mdl-cell--12-col">
         <h4 >Exportation des demandes au format CSV</h4>

--- a/app/views/allApplications.scala.html
+++ b/app/views/allApplications.scala.html
@@ -1,7 +1,7 @@
 @(currentUser: User)(applications: Seq[Application], selectedArea: Area)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 @import java.util.Locale
 
-@main(currentUser, selectedArea, false, maxWidth = false)(s"Demandes")  {
+@main(currentUser, maxWidth = false)(s"Demandes")  {
 <style>
     .pem-table {
         width: 100%;

--- a/app/views/allArea.scala.html
+++ b/app/views/allArea.scala.html
@@ -1,9 +1,9 @@
 @import models._
 @import java.util.UUID
-@(user: User, currentArea: Area)(areas: Seq[Area], areasWithLoginByKey: Seq[UUID], userGroups: List[UserGroup])(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(user: User)(areas: Seq[Area], areasWithLoginByKey: Seq[UUID], userGroups: List[UserGroup])(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
 
-@main(user, currentArea, false)(s"Gestion des territoires"){
+@main(user)(s"Gestion des territoires"){
 
 }{
     <div class="mdl-cell mdl-cell--12-col pem-container mdl-grid">
@@ -11,7 +11,7 @@
         <table class="mdl-cell mdl-cell--12-col mdl-data-table mdl-js-data-table pem-table mdl-shadow--2dp" style="white-space: normal;">
             <thead>
                 <tr>
-                    <th class="mdl-data-table__cell--non-numeric @if(area.id == currentArea.id){ mdl-color-text--black }">
+                    <th class="mdl-data-table__cell--non-numeric">
                         @area.name
                         @if(user.admin) { /
                             @area.id /

--- a/app/views/allEvents.scala.html
+++ b/app/views/allEvents.scala.html
@@ -1,8 +1,8 @@
-@(user: User, area: Area)(events: Seq[Event], limit: Int)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(user: User)(events: Seq[Event], limit: Int)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 @import java.util.Locale
 
 
-@main(user, area, false, maxWidth = false)(s"Evénements ($limit derniers)")  {
+@main(user, maxWidth = false)(s"Evénements ($limit derniers)")  {
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("sortable/sortable.css")'>
     <script src="@routes.Assets.versioned("sortable/sortable.js")"></script>
 }{

--- a/app/views/allUsers.scala.html
+++ b/app/views/allUsers.scala.html
@@ -67,7 +67,7 @@
         </tbody>
       </table>
   }
-@main(currentUser, selectedArea, false)(s"Gestion des groupes utilisateurs - ${selectedArea.name}") {
+@main(currentUser)(s"Gestion des groupes utilisateurs - ${selectedArea.name}") {
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/newForm.css")'>
 
   <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/auto-complete.css")'>

--- a/app/views/createApplication.scala.html
+++ b/app/views/createApplication.scala.html
@@ -2,7 +2,7 @@
 @import extentions.MDLForms._
 @(user: User, area: Area)(users: List[User], organisationGroups: List[UserGroup], applicationForm: Form[forms.Models.ApplicationData], attachments: Iterable[String] = Nil)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
 
-@main(user, area)(s"Nouvelle demande")  {
+@main(user, Some(area))(s"Nouvelle demande")  {
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/newForm.css")'>
     <script src='@routes.Assets.versioned("javascripts/application-attachment.js")'></script>
     <style>

--- a/app/views/editGroup.scala.html
+++ b/app/views/editGroup.scala.html
@@ -1,8 +1,8 @@
 @import models._
-@(currentUser: User, area: Area)(userGroup: UserGroup, groupUsers: List[User], isEmpty: Boolean, zoneAsJson: String, geoplusHost: String)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(currentUser: User)(userGroup: UserGroup, groupUsers: List[User], isEmpty: Boolean, zoneAsJson: String, geoplusHost: String)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
 
-@main(currentUser, area, false)(s"Gestion du groupe ${userGroup.name} - ${Area.fromId(userGroup.area).get.name}") {
+@main(currentUser)(s"Gestion du groupe ${userGroup.name} - ${Area.fromId(userGroup.area).get.name}") {
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/newForm.css")'>
     <script src='@routes.Assets.versioned("javascripts/group.js")'></script>
 

--- a/app/views/editUser.scala.html
+++ b/app/views/editUser.scala.html
@@ -1,9 +1,9 @@
 @import models._
 @import extentions.MDLForms._
 @import java.util.UUID
-@(currentUser: User, area: Area)(form: Form[User], userId: UUID, userGroups: List[UserGroup], unused: Boolean = false, tokenName: String = "", tokenValue: String = "")(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
+@(currentUser: User)(form: Form[User], userId: UUID, userGroups: List[UserGroup], unused: Boolean = false, tokenName: String = "", tokenValue: String = "")(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
 
-@main(currentUser, area, false)(s"Utilisateur ${form.get.name}") {
+@main(currentUser)(s"Utilisateur ${form.get.name}") {
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/newForm.css")'>
 
 }{

--- a/app/views/editUsers.scala.html
+++ b/app/views/editUsers.scala.html
@@ -1,9 +1,9 @@
 @import models._
 @import extentions.MDLForms._
-@(user: User, area: Area)(form: Form[(List[User])], min: Int, action: Call)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
+@(user: User)(form: Form[(List[User])], min: Int, action: Call)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
 
 
-@main(user, area, false)(s"Gestion des utilisateurs") {
+@main(user)(s"Gestion des utilisateurs") {
     @webJarsUtil.locate("dialog-polyfill.css").css()
   <style>
           .pem-table {

--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -1,6 +1,6 @@
-@(user: User, area: Area)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(user: User)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
-@main(user, area, false)("Webinaire")  {
+@main(user)("Webinaire")  {
 
 }{
      <div class="mdl-color--white mdl-shadow--2dp mdl-cell mdl-cell--12-col --padding-20px">

--- a/app/views/importUsers.scala.html
+++ b/app/views/importUsers.scala.html
@@ -1,8 +1,8 @@
 @import models._
 @import extentions.MDLForms._
-@(currentUser: User, area: Area)(csvImportContent: String, errors: List[FormError])(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
+@(currentUser: User)(csvImportContent: String, errors: List[FormError])(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
 
-@main(currentUser, area)(s"Importer des utilisateurs") {
+@main(currentUser)(s"Importer des utilisateurs") {
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/newForm.css")'>
 } {
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @import helper._
 
-@(currentUser: User, currentArea: Area, showAreaSelector: Boolean = true, maxWidth: Boolean = true)(title: String)(header: Html)(content: Html)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(currentUser: User, currentArea: Option[Area] = None, maxWidth: Boolean = true)(title: String)(header: Html)(content: Html)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
 <!doctype html>
 <html lang="fr">
@@ -70,10 +70,12 @@
                     request.send("email="+email);
                 }
 
-                function changeArea() {
-                    var areaSelected = document.getElementById("area").value;
-                    if(areaSelected != "@currentArea.id") {
-                        document.location = "@routes.AreaController.all()/"+areaSelected+"?redirect="+window.location.href;
+                @if(currentArea.nonEmpty) {
+                    function changeArea() {
+                        var areaSelected = document.getElementById("area").value;
+                        if(areaSelected != "@currentArea.get.id") {
+                            document.location = "@routes.AreaController.all()/"+areaSelected+"?redirect="+window.location.href;
+                        }
                     }
                 }
         </script>
@@ -119,12 +121,12 @@
                     <p style="line-height: 1.2; text-align: center;">
                         <img src='@routes.Assets.versioned("images/logo_full_500x397.png")' class="logo">
                     </p>
-                    <div class="demo-avatar-dropdown">
-                        @if(showAreaSelector && currentUser.areas.length > 1) {
+                    <div>
+                        @if(currentArea.nonEmpty && currentUser.areas.length > 1) {
                             <select id="area" name="area" onchange="changeArea()">
                             @for(area <- currentUser.areas.flatMap(Area.fromId)) {
                                 <option value="@area.id"
-                                @if(area.id == currentArea.id) { selected }>@area.name </option>
+                                @if(area.id == currentArea.get.id) { selected }>@area.name </option>
                             }
                             </select>
                         }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -98,16 +98,7 @@
                             <li class="mdl-list__item mdl-list__item--two-line">
                                 <span class="mdl-list__item-primary-content">
                                     <span>@currentUser.name</span>
-                                    <span class="mdl-list__item-sub-title">  @if(showAreaSelector && currentUser.areas.length > 1) {
-                                        <select id="area" name="area" onchange="changeArea()">
-                                        @for(area <- currentUser.areas.flatMap(Area.fromId)) {
-                                            <option value="@area.id"
-                                            @if(area.id == currentArea.id) { selected }>@area.name </option>
-                                        }
-                                        </select>
-                                    } else {
-                                        @currentArea.name
-                                    }</span>
+                                    <span class="mdl-list__item-sub-title">@currentUser.email</span>
                                 </span>
                                 <span class="mdl-list__item-secondary-content">
                                     <a class="mdl-list__item-secondary-action mdl-button mdl-js-button mdl-button--icon mdl-js-ripple-effect" href="@routes.LoginController.disconnect()" title="Déconnexion">
@@ -129,7 +120,14 @@
                         <img src='@routes.Assets.versioned("images/logo_full_500x397.png")' class="logo">
                     </p>
                     <div class="demo-avatar-dropdown">
-                        <span style="font-size: 11px;">@currentUser.email</span>
+                        @if(showAreaSelector && currentUser.areas.length > 1) {
+                            <select id="area" name="area" onchange="changeArea()">
+                            @for(area <- currentUser.areas.flatMap(Area.fromId)) {
+                                <option value="@area.id"
+                                @if(area.id == currentArea.id) { selected }>@area.name </option>
+                            }
+                            </select>
+                        }
                     </div>
                 </header>
                 <nav class="navigation mdl-navigation mdl-color--blue-grey-800">

--- a/app/views/myApplications.scala.html
+++ b/app/views/myApplications.scala.html
@@ -1,4 +1,4 @@
-@(user: User, area: Area)(myOpenApplications: Seq[Application], myClosedApplications: Seq[Application], applicationsFromTheArea: Seq[Application] = List())(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
+@(user: User)(myOpenApplications: Seq[Application], myClosedApplications: Seq[Application], applicationsFromTheArea: Seq[Application] = List())(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 @import java.util.Locale
 
 @display(applications: Seq[Application]) = {
@@ -47,7 +47,7 @@
     </div>
 }
 
-@main(user, area, false)(s"Mes demandes")  {
+@main(user)(s"Mes demandes")  {
 <style>
     .pem-table {
         width: 100%;

--- a/app/views/reviewUsersImport.scala.html
+++ b/app/views/reviewUsersImport.scala.html
@@ -1,7 +1,7 @@
 @import models._
 @import extentions.MDLForms._
 
-@(currentUser: User, area: Area)(form: Form[(List[csv.Section], java.util.UUID)])(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
+@(currentUser: User)(form: Form[(List[csv.Section], java.util.UUID)])(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
 
 @display(section: Field)(header: Html)(footer: Html) = {
 <table class="mdl-cell mdl-cell--12-col mdl-data-table mdl-js-data-table pem-table mdl-shadow--2dp mdl-color--white">
@@ -51,7 +51,7 @@
 </table>
 }
 
-@main(currentUser, area, false)("Revue de votre import CSV") {
+@main(currentUser)("Revue de votre import CSV") {
   <script src='@routes.Assets.versioned("javascripts/csv-import.js")'></script>
 } {
   @helper.form(routes.UserController.importUsers(), 'method -> "post", 'class -> "mdl-cell mdl-cell--12-col") {

--- a/app/views/showApplication.scala.html
+++ b/app/views/showApplication.scala.html
@@ -1,7 +1,7 @@
-@(user: User, area: Area)(usersThatCanBeInvited: List[User], application: Application, answerToAgentsForm: Form[_], attachments: Iterable[String] = Nil)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
+@(user: User)(usersThatCanBeInvited: List[User], application: Application, answerToAgentsForm: Form[_], attachments: Iterable[String] = Nil)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
 @import java.util.Locale
 
-@main(user, area, false)(s"Demande de ${application.creatorUserName}")  {
+@main(user)(s"Demande de ${application.creatorUserName} - ${Area.fromId(application.area).get.name}")  {
 <style>
 .mdl-list__item-primary-content {
     font-weight: bold;

--- a/app/views/showCGU.scala.html
+++ b/app/views/showCGU.scala.html
@@ -1,8 +1,8 @@
 @import models._
 @import extentions.MDLForms._
-@(user: User, area: Area)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
+@(user: User)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
 
-@main(user, area, false)("Conditions générales d'utilisations")  {
+@main(user)("Conditions générales d'utilisations")  {
 <style>
     .mdl-data-table td {
         padding: 0px 18px;

--- a/app/views/simplifiedCreateApplication.scala.html
+++ b/app/views/simplifiedCreateApplication.scala.html
@@ -1,9 +1,9 @@
 @import models._
 @import extentions.MDLForms._
 @import models.Organisation.Category
-@(user: User, area: Area)(users: List[User], organisationGroups: List[UserGroup], categories: Seq[Category], selectedCategory: Option[String], applicationForm: Form[forms.Models.ApplicationData], attachments: Iterable[String] = Nil)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
+@(user: User, currentArea: Area)(users: List[User], organisationGroups: List[UserGroup], categories: Seq[Category], selectedCategory: Option[String], applicationForm: Form[forms.Models.ApplicationData], attachments: Iterable[String] = Nil)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
 
-@main(user, area)(s"Nouvelle demande"){
+@main(user, Some(currentArea))(s"Nouvelle demande"){
     <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/newForm.css")'>
 
     <style>

--- a/app/views/stats.scala.html
+++ b/app/views/stats.scala.html
@@ -4,7 +4,7 @@
 @import extentions.Math
 @(user: User, area: Area)(months: ListMap[String, String], allApplications: Map[Area, Seq[Application]], users: List[User], currentAreaOnly: Boolean)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
-@main(user, area)(s"Stats")  {
+@main(user, Some(area))(s"Stats")  {
     <style xmlns="http://www.w3.org/1999/html">
         td {
             cursor: pointer;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -49,19 +49,7 @@ html, body {
           justify-content: flex-end;
   padding: 16px;
 }
-.demo-avatar-dropdown {
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
-  -webkit-align-items: center;
-      -ms-flex-align: center;
-          align-items: center;
-  width: 100%;
-}
+
 
 .navigation {
   -webkit-flex-grow: 1;


### PR DESCRIPTION
> Note : il y a une notion de "territoire en cours" (qui sauvegardé dans le navigateur) qui est perturbant pour les utilisateurs (cause des erreurs aux administrateurs et affiche des vues trompeur). Cette Pull Request supprime en bonne partie cette notion et la laisse qu'au endroit où c'est encore utiliser dans l'application (avant une suppression totale). 

## Changements fonctionnelles

- [X] Affiche de l'email sous le pseudo
![image](https://user-images.githubusercontent.com/1238254/70462318-ee271780-1aba-11ea-89fb-3812dc549c0f.png)
- [X] Du territoire en cours apparait que si l'utilisateur est multi-territoire et que la page tiens en compte d'une territoire en cours (page de création de demande, page de stats uniquement)
![image](https://user-images.githubusercontent.com/1238254/70462375-0434d800-1abb-11ea-8569-c93cddeeec20.png)
- [X] Les personnes pouvant être invité sont ceux du territoire de la demande (et non du territoire en cours de l'utilisateur)

## Changements techniques

- Suppression du territoire de la réponse (une réponse est embarqué dans la demande)
- Suppression des anciens objets de stockage de réponses
- Suppression d'un maximum de référence du territoire courant