### PR TITLE
Conflit entre nom d'utilisateur et nom du groupe

### DIFF
--- a/app/csv/package.scala
+++ b/app/csv/package.scala
@@ -16,7 +16,7 @@ package object csv {
 
   val GROUP_AREAS_IDS = Header("group.area-ids", List("Territoire", "DEPARTEMENTS"))
   val GROUP_ORGANISATION = Header("group.organisation", List("Organisation"))
-  val GROUP_NAME = Header("group.name", List("Groupe", "Opérateur partenaire", "Nom de la structure labellisable"))
+  val GROUP_NAME = Header("group.name", List("Groupe", "Opérateur partenaire")) // "Nom de la structure labellisable"
   val GROUP_EMAIL = Header("group.email", List("Bal", "adresse mail générique"))
 
   val SEPARATOR = ";"

--- a/test/csv/CSVSpec.scala
+++ b/test/csv/CSVSpec.scala
@@ -33,8 +33,9 @@ class CSVSpec extends Specification {
       |,,,,,
       |""".stripMargin
 
+  //TODO : In the future, manage "Nom de la structure labellisable"
   val organisationTest: String =
-    """organisation,Nom de la structure labellisable,Adresse,Code Postal,Commune,Nom Agent,Prénom Agent,Contact mail Agent,Bal,"Coordonnées du référent préfectoral en charge du dossier France Services"
+    """organisation,Groupe,Adresse,Code Postal,Commune,Nom Agent,Prénom Agent,Contact mail Agent,Bal,"Coordonnées du référent préfectoral en charge du dossier France Services"
       |MSAP,d’Aubigny sur Nère,6 rue du 8 mai 1945,18700,Aubigny sur Nère,Nom1,Prénom1,test1@aubigny-sur-nere.fr,msap@aubigny-sur-nere.fr,
       |MSAP,d’Aubigny sur Nère,6 rue du 8 mai 1945,18700,Aubigny sur Nère,Nom2,Prénom2,test2@aubigny-sur-nere.fr,msap@aubigny-sur-nere.fr,
       |MSAP,d’Aubigny sur Nère,6 rue du 8 mai 1945,18700,Aubigny sur Nère,Nom3,Prénom3,test3@aubigny-sur-nere.fr,msap@aubigny-sur-nere.fr,


### PR DESCRIPTION
"Nom de la structure labellisable" était pris comme nom de l'utilisateur.
On a vu de supprimer le support de "Nom de la structure labellisable" (ils remplaceront par "Groupe").

On pourra améliorer l'import pour éviter d'utiliser un champs 2 fois.