### PR TITLE
[416] Ne pas afficher d'erreur d'identification sur la page racine.

### DIFF
--- a/app/actions/LoginAction.scala
+++ b/app/actions/LoginAction.scala
@@ -60,9 +60,7 @@ class LoginAction @Inject()(val parser: BodyParsers.Default,
           eventService.log(UserAccessDisabled, s"Utilisateur désactivé essaye d'accèder à la page ${request.path}}")
           userNotLogged(s"Votre compte a été désactivé. Contactez votre référent ou l'équipe d'Administration+ sur ${Constants.supportEmail} en cas de problème.")
         case _ =>
-          if (path == routes.HomeController.index().url) {
-            userNotLoggedOnLoginPage
-          } else {
+          if (path != routes.HomeController.index().url) {
             val message = request.getQueryString("token") match {
               case Some(token) =>
                 eventService.info(User.systemUser, Area.notApplicable, request.remoteAddress, "UNKNOWN_TOKEN", s"Token $token est inconnue", None, None)
@@ -72,6 +70,8 @@ class LoginAction @Inject()(val parser: BodyParsers.Default,
                 "Vous devez vous identifier pour accèder à cette page."
             }
             userNotLogged(message)
+          } else {
+            userNotLoggedOnLoginPage
           }
       }
     }

--- a/app/actions/LoginAction.scala
+++ b/app/actions/LoginAction.scala
@@ -59,18 +59,20 @@ class LoginAction @Inject()(val parser: BodyParsers.Default,
           implicit val requestWithUserData = new RequestWithUserData(user, area, request)
           eventService.log(UserAccessDisabled, s"Utilisateur désactivé essaye d'accèder à la page ${request.path}}")
           userNotLogged(s"Votre compte a été désactivé. Contactez votre référent ou l'équipe d'Administration+ sur ${Constants.supportEmail} en cas de problème.")
-        case _ if request.path == routes.HomeController.index().url =>
-          userNotLoggedOnLoginPage
         case _ =>
-          val message = request.getQueryString("token") match {
-            case Some(token) =>
-              eventService.info(User.systemUser, Area.notApplicable, request.remoteAddress, "UNKNOWN_TOKEN", s"Token $token est inconnue", None, None)
-              "Le lien que vous avez utilisé n'est plus valide, il a déjà été utilisé. Si cette erreur se répète, contactez l'équipe Administration+"
-            case None =>
-              Logger.warn(s"Accès à la ${request.path} non autorisé")
-              "Vous devez vous identifier pour accèder à cette page."
+          if (path == routes.HomeController.index().url) {
+            userNotLoggedOnLoginPage
+          } else {
+            val message = request.getQueryString("token") match {
+              case Some(token) =>
+                eventService.info(User.systemUser, Area.notApplicable, request.remoteAddress, "UNKNOWN_TOKEN", s"Token $token est inconnue", None, None)
+                "Le lien que vous avez utilisé n'est plus valide, il a déjà été utilisé. Si cette erreur se répète, contactez l'équipe Administration+"
+              case None =>
+                Logger.warn(s"Accès à la ${request.path} non autorisé")
+                "Vous devez vous identifier pour accèder à cette page."
+            }
+            userNotLogged(message)
           }
-          userNotLogged(message)
       }
     }
 

--- a/app/actions/LoginAction.scala
+++ b/app/actions/LoginAction.scala
@@ -59,6 +59,8 @@ class LoginAction @Inject()(val parser: BodyParsers.Default,
           implicit val requestWithUserData = new RequestWithUserData(user, area, request)
           eventService.log(UserAccessDisabled, s"Utilisateur désactivé essaye d'accèder à la page ${request.path}}")
           userNotLogged(s"Votre compte a été désactivé. Contactez votre référent ou l'équipe d'Administration+ sur ${Constants.supportEmail} en cas de problème.")
+        case _ if request.path == routes.HomeController.index().url =>
+          userNotLoggedOnLoginPage
         case _ =>
           val message = request.getQueryString("token") match {
             case Some(token) =>
@@ -112,6 +114,9 @@ class LoginAction @Inject()(val parser: BodyParsers.Default,
 
   private def userNotLogged[A](message: String)(implicit request: Request[A]) = Left(TemporaryRedirect(routes.LoginController.login().url)
     .withSession(request.session - "userId").flashing("error" -> message))
+
+  private def userNotLoggedOnLoginPage[A](implicit request: Request[A]) =
+    Left(TemporaryRedirect(routes.LoginController.login().url).withSession(request.session - "userId"))
 
   private def tokenById[A](implicit request: Request[A]) = request.getQueryString("token").flatMap(tokenService.byToken)
   private def userByKey[A](implicit request: Request[A]) = request.getQueryString("key").flatMap(userService.byKey)

--- a/test/browser/HomeSpec.scala
+++ b/test/browser/HomeSpec.scala
@@ -11,13 +11,12 @@ class HomeSpec extends Specification with Tables with BaseSpec {
   
   "Home" should {
     "Redirect to /login when disconnected" in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = applicationWithBrowser) {
-      val loginURL = controllers.routes.HomeController.index().absoluteURL(false, s"localhost:$port")
+      val homeUrl = controllers.routes.HomeController.index().absoluteURL(false, s"localhost:$port")
 
-      browser.goTo(loginURL)
+      browser.goTo(homeUrl)
 
 
       browser.url must endWith(controllers.routes.LoginController.login().url.substring(1))
-      browser.pageSource must contain("Vous devez vous identifier pour accèder à cette page.")
     }
 
     "Status up" in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = applicationWithBrowser) {

--- a/test/browser/LoginSpec.scala
+++ b/test/browser/LoginSpec.scala
@@ -63,7 +63,7 @@ class gLoginSpec extends Specification with Tables with BaseSpec {
     "Use token without success"  in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = applicationWithBrowser) {
       val loginURL = controllers.routes.LoginController.magicLinkAntiConsumptionPage().absoluteURL(false, s"localhost:$port")
 
-      browser.goTo(s"$loginURL?token=90798798789798&path=/nouvelle-demande")
+      browser.goTo(s"$loginURL?token=90798798789798&path=/")
 
       eventually {
         browser.url must endWith(controllers.routes.LoginController.login().url.substring(1))

--- a/test/browser/LoginSpec.scala
+++ b/test/browser/LoginSpec.scala
@@ -63,7 +63,7 @@ class gLoginSpec extends Specification with Tables with BaseSpec {
     "Use token without success"  in new WithBrowser(webDriver = WebDriverFactory(HTMLUNIT), app = applicationWithBrowser) {
       val loginURL = controllers.routes.LoginController.magicLinkAntiConsumptionPage().absoluteURL(false, s"localhost:$port")
 
-      browser.goTo(s"$loginURL?token=90798798789798&path=/")
+      browser.goTo(s"$loginURL?token=90798798789798&path=/nouvelle-demande")
 
       eventually {
         browser.url must endWith(controllers.routes.LoginController.login().url.substring(1))


### PR DESCRIPTION
Si la page demandée est l'index, ne pas requérir d'information d'identification.