### PR TITLE
Amélioration Github Actions pour les PR externes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         GEOPLUS_HOST: geoplus.aplus.beta.gouv.fr
     - name: Upload Coverage to codacy
-      if: secrets.CODACY_PROJECT_TOKEN != null
+      if: secrets.CODACY_PROJECT_TOKEN
       run: sbt codacyCoverage
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,11 @@ jobs:
          postgresql user: 'aplus'
          postgresql password: 'mysecretpassword'
     - name: Run test
-      run: sbt coverage test coverageReport codacyCoverage
+      run: sbt coverage test coverageReport 
+      env:
+        GEOPLUS_HOST: geoplus.aplus.beta.gouv.fr
+    - name: Upload Coverage to codacy
+      run: sbt codacyCoverage
+      if: secrets.CODACY_PROJECT_TOKEN != null
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        GEOPLUS_HOST: geoplus.aplus.beta.gouv.fr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
       env:
         GEOPLUS_HOST: geoplus.aplus.beta.gouv.fr
     - name: Upload Coverage to codacy
-      if: secrets.CODACY_PROJECT_TOKEN
-      run: sbt codacyCoverage
+      run: |
+         if [ "$CODACY_PROJECT_TOKEN" != "" ]; then
+            sbt codacyCoverage
+         fi
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       env:
         GEOPLUS_HOST: geoplus.aplus.beta.gouv.fr
     - name: Upload Coverage to codacy
+      if: secrets.CODACY_PROJECT_TOKEN != null
       run: sbt codacyCoverage
-      if: ${{ secrets.CODACY_PROJECT_TOKEN != null }}
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
         GEOPLUS_HOST: geoplus.aplus.beta.gouv.fr
     - name: Upload Coverage to codacy
       run: sbt codacyCoverage
-      if: secrets.CODACY_PROJECT_TOKEN != null
+      if: ${{ secrets.CODACY_PROJECT_TOKEN != null }}
       env:
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
- Codacy upload en optionnel
- Lance les tests uniquements sur les pulls requests (sinon il se lance en double)