### PR TITLE
Met les notifications en haut de la page au lieu de l'intérieur de la snackbar.

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -904,8 +904,11 @@ case class ApplicationController @Inject() (
           if (applicationService.close(applicationId, finalUsefulness, DateTime.now(timeZone))) {
             eventService
               .log(TerminateCompleted, s"La demande $applicationId est clôturée", Some(application))
+            val successMessage =
+              s"""|La demande "${application.subject}" a bien été clôturée. 
+                  |Bravo et merci pour la résolution de cette demande !""".stripMargin
             Redirect(routes.ApplicationController.myApplications())
-              .flashing("success" -> "L'application a été indiquée comme clôturée")
+              .flashing("success" -> successMessage)
           } else {
             eventService.log(
               TerminateError,

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -15,6 +15,7 @@
         @webJarsUtil.locate("fontawesome.css").css()
         @webJarsUtil.locate("solid.css").css()
         <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/main.css")'>
+        <link rel="stylesheet" media="screen,print" href='@routes.Assets.versioned("stylesheets/mdl-extensions.css")'>
 
         @header
         @webJarsUtil.locate("material.min.js").script()
@@ -148,7 +149,8 @@
             </div>
 
             <main class="mdl-layout__content mdl-color--grey-200">
-                <div class="mdl-grid main__grid" style="min-height: 800px; @if(maxWidth) { max-width: 960px; }">
+                <div class="mdl-grid main__grid" style="@if(maxWidth) { max-width: 960px; }">
+
                 @flash.get("error").map { error =>
                     <div class="mdl-cell mdl-cell--12-col" id="answer-error">
                         <div class="notification notification--error"><b>@error</b><br>
@@ -156,22 +158,40 @@
                         </div>
                     </div>
                 }
-                @content
-                </div>
-                <footer class="mdl-mega-footer do-not-print">
-                    <div class="mdl-mega-footer--bottom-section">
-                        <div class="mdl-logo">
-                            Administration+ @java.time.LocalDate.now().getYear() :
-                        </div>
-                        <ul class="mdl-mega-footer--link-list">
-                            <li><a href="@routes.HomeController.help()">Aide</a></li>
-                            <li><a href="@routes.UserController.showCGU()">CGU</a></li>
-                            <li><a href="@routes.ApplicationController.showExportMyApplicationsCSV()">Exporter mes demandes en CSV</a></li>
-                        </ul>
-                    </div>
-                </footer>
 
+
+                @flash.get("success").map { message =>
+                    <div class="mdl-cell mdl-cell--12-col">
+                      <div class="notification notification--success">
+                        <div class="notification__message">
+                          @message
+                        </div>
+                        <button class="notification__close-btn mdl-button mdl-js-button mdl-button--icon">
+                          <i class="material-icons">close</i>
+                        </button>
+                      </div>
+                    </div>
+                }
+
+                    @content
+                </div>
             </main>
+
+
+            <footer class="mdl-layout__footer mdl-mega-footer do-not-print">
+                <div class="mdl-mega-footer--bottom-section">
+                    <div class="mdl-logo">
+                        Administration+ @java.time.LocalDate.now().getYear() :
+                    </div>
+                    <ul class="mdl-mega-footer--link-list">
+                        <li><a href="@routes.HomeController.help()">Aide</a></li>
+                        <li><a href="@routes.UserController.showCGU()">CGU</a></li>
+                        <li><a href="@routes.ApplicationController.showExportMyApplicationsCSV()">Exporter mes demandes en CSV</a></li>
+                    </ul>
+                </div>
+            </footer>
+
+
             <div aria-live="assertive" aria-atomic="true" aria-relevant="text" class="mdl-snackbar mdl-js-snackbar">
                 <div class="mdl-snackbar__text"></div>
                 <button type="button" class="mdl-snackbar__action"></button>
@@ -198,6 +218,7 @@
         <script>
           // TODO: put this in main.js, and load main.js at the end of this file
           setupProtectedForms();
+          setupNotificationMessages();
 
                 if(/localhost|demo/.test(window.location.hostname)) {
                     document.getElementById("header__ribbon").classList.add("invisible");
@@ -209,4 +230,3 @@
         </script>
     </body>
 </html>
-

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -127,3 +127,27 @@ function setupProtectedForms() {
     setupOneProtectedForm(forms[fi]);
   }
 }
+
+
+//
+// Notification Messages
+//
+
+// Will add onClick listeners on `.notification__close-btn` that remove the `.notification` element
+function setupNotificationMessages() {
+  var elems = document.querySelectorAll(".notification");
+  for (var i = 0; i < elems.length; i++) {
+    var closeBtn = elems[i].querySelector(".notification__close-btn");
+    if (closeBtn != null) {
+      onClickRemoveElement(closeBtn, elems[i])
+    }
+  }
+}
+
+function onClickRemoveElement(clickElement, elementToRemove) {
+  clickElement.addEventListener("click", function() {
+    // Cross browser
+    // https://stackoverflow.com/questions/3387427/remove-element-by-id
+    elementToRemove.outerHTML = ""
+  })
+}

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -413,7 +413,9 @@ a {
     padding: 20px;
 }
 
-
+/* https://github.com/etalab/template.data.gouv.fr/blob/master/src/css/components/notification.css
+ * https://github.com/etalab/template.data.gouv.fr/blob/master/src/css/base/theme.css
+ */
 .notification {
     background: #b4e1fa;
     border: 1px solid #006be6;
@@ -421,12 +423,25 @@ a {
     padding: 1em;
     margin-bottom: 1em;
     position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.notification--success {
+    background: #daf5e7;
+    border-color: #03bd5b;
 }
 
 .notification--error {
     background: rgba(239,172,166,0.45882);
     border-color: #d63626;
 }
+
+.notification__message {
+    flex-grow: 1;
+}
+
+
 
 .avoid-clicks {
     pointer-events: none;

--- a/public/stylesheets/mdl-extensions.css
+++ b/public/stylesheets/mdl-extensions.css
@@ -5,3 +5,13 @@
 .mdl-typography--text-prewrap {
     white-space: pre-wrap;
 }
+
+.mdl-layout--fixed-drawer > .mdl-layout__footer {
+    margin-left: 240px;
+}
+
+@media screen and (max-width: 1024px) {
+    .mdl-layout--fixed-drawer > .mdl-layout__footer {
+        margin-left: 0;
+    }
+}

--- a/public/stylesheets/mdl-extensions.css
+++ b/public/stylesheets/mdl-extensions.css
@@ -6,6 +6,9 @@
     white-space: pre-wrap;
 }
 
+/* Inspired by:
+ * https://github.com/google/material-design-lite/blob/mdl-1.x/src/layout/_layout.scss#L449
+ */
 .mdl-layout--fixed-drawer > .mdl-layout__footer {
     margin-left: 240px;
 }


### PR DESCRIPTION
Le footer est mieux placé dans le DOM et ne provoque plus de défauts visuels.
Change le message lorsqu'une application est clôturée.

<img width="995" alt="Screen Shot 2020-02-24 at 17 49 35" src="https://user-images.githubusercontent.com/4394842/75173981-0a3c6b80-5730-11ea-9dc7-9f0430a99bb8.png">
<img width="1021" alt="Screen Shot 2020-02-24 at 17 39 31" src="https://user-images.githubusercontent.com/4394842/75173992-0f99b600-5730-11ea-98e5-ddf203042fa9.png">

(note: j'ai changé "cloturée" en "clôturée", ça a l'air d'être l'orthographe correcte)