### PR TITLE
Corrige affichage du nom et email utilisateur

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -78,7 +78,7 @@
                         <!-- Add spacer, to align navigation to the right in desktop -->
                     <div class="mdl-layout-spacer"></div>
                     <div class="hidden--small-screen">
-                        <ul class="mdl-list" style="width: 300px;">
+                        <ul class="mdl-list">
                             <li class="mdl-list__item mdl-list__item--two-line">
                                 <span class="mdl-list__item-primary-content">
                                     <span>@currentUser.name</span>


### PR DESCRIPTION
Avant : 
![image](https://user-images.githubusercontent.com/1238254/75175890-779dcb80-5733-11ea-9849-ecb9dad1c3b7.png)
Après : 
![image](https://user-images.githubusercontent.com/1238254/75175909-7ec4d980-5733-11ea-985a-6a0102185d72.png)
