### PR TITLE
Ajoute le header COVID. Corrige le header de demo (s'affiche en prod).

### DIFF
--- a/app/views/home/page.scala.html
+++ b/app/views/home/page.scala.html
@@ -49,7 +49,7 @@
                 </div>
 
                 <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white">
-                    France services et Administration+ se mobilisent pendant le confinement. Merci de votre implication si nécessaire en cette période. Des milliers de nouveaux blocages risquent de survenir. Remportons ce combat ! Bon courage à tous.
+                    France Services et Administration+ se mobilisent pendant le confinement. Merci de votre implication si nécessaire en cette période. Des milliers de nouveaux blocages risquent de survenir. Remportons ce combat ! Bon courage à tous.
                 </div>
 
                 <div class="mdl-layout__header-row">

--- a/app/views/home/page.scala.html
+++ b/app/views/home/page.scala.html
@@ -42,11 +42,16 @@
     <body>
         <div class="mdl-layout mdl-layout--fixed-header mdl-js-layout">
             <header class="mdl-layout__header mdl-color--white">
-                <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white">
+                <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white invisible demo-only">
                     <span class="mdl-layout-title aplus-demo-header__title">
-                Version de démonstration d’Administration+
+                        Version de démonstration d’Administration+
                     </span>
                 </div>
+
+                <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white">
+                    France services et Administration+ se mobilisent pendant le confinement. Merci de votre implication si nécessaire en cette période. Des milliers de nouveaux blocages risquent de survenir. Remportons ce combat ! Bon courage à tous.
+                </div>
+
                 <div class="mdl-layout__header-row">
                     <div class="mdl-layout-title mdl-layout-title--plus">
                         <img
@@ -367,5 +372,6 @@
                 </div>
             </div>
         </footer>
+        <script type="application/javascript" src="@routes.Assets.versioned("javascripts/main-page-bottom.js")"></script>
     </body>
 </html>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -40,11 +40,14 @@
         </div>
         <div class="demo-layout mdl-layout mdl-js-layout mdl-layout--fixed-header mdl-layout--fixed-drawer">
             <div class="mdl-layout__header mdl-color--grey-100 mdl-color-text--grey-600 do-not-print">
-                <div class="mdl-layout__header mdl-color-text--grey-500 do-not-print mdl-color--grey-100 demo-only invisible">
-                    <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white">
+                <div class="mdl-layout__header mdl-color-text--grey-500 do-not-print mdl-color--grey-100">
+                    <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white invisible demo-only">
                         <span class="mdl-layout-title aplus-demo-header__title">
                             Version de démonstration d’Administration+
                         </span>
+                    </div>
+                    <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white">
+                        France services et Administration+ se mobilisent pendant le confinement. Merci de votre implication si nécessaire en cette période. Des milliers de nouveaux blocages risquent de survenir. Remportons ce combat ! Bon courage à tous.
                     </div>
                 </div>
                 <div class="mdl-layout__header-row">
@@ -126,7 +129,7 @@
 
                     @content
                 </div>
-                <footer class="mdl-mega-footer do-not-print">
+                <footer class="mdl-mega-footer mdl-mega-footer-fix do-not-print">
                     <div class="mdl-mega-footer--bottom-section">
                         <div class="mdl-logo">
                             Administration+ @java.time.LocalDate.now().getYear() :

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -47,7 +47,7 @@
                         </span>
                     </div>
                     <div class="mdl-layout__header-row mdl-color--pink-500 mdl-color-text--white">
-                        France services et Administration+ se mobilisent pendant le confinement. Merci de votre implication si nécessaire en cette période. Des milliers de nouveaux blocages risquent de survenir. Remportons ce combat ! Bon courage à tous.
+                        France Services et Administration+ se mobilisent pendant le confinement. Merci de votre implication si nécessaire en cette période. Des milliers de nouveaux blocages risquent de survenir. Remportons ce combat ! Bon courage à tous.
                     </div>
                 </div>
                 <div class="mdl-layout__header-row">

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -113,6 +113,13 @@ html, body {
     z-index: 10;
 }
 
+/* Note: the mdl footer has too much padding at the bottom and demands a
+ * mandatory scroll
+ */
+.mdl-mega-footer-fix {
+    padding-bottom: 4px;
+}
+
 .mdl-card__supporting-text {
     width: 100% !important;
     box-sizing: border-box;


### PR DESCRIPTION
Page interne (prod) :
<img width="1116" alt="Screen Shot 2020-04-14 at 19 52 04" src="https://user-images.githubusercontent.com/4394842/79258073-defe0f00-7e8a-11ea-9a48-c66d5e09e6a2.png">

Page interne (demo)
<img width="1138" alt="Screen Shot 2020-04-14 at 19 49 21" src="https://user-images.githubusercontent.com/4394842/79258105-efae8500-7e8a-11ea-92b3-8911961626ee.png">

Page externe (prod)
<img width="1331" alt="Screen Shot 2020-04-14 at 19 55 01" src="https://user-images.githubusercontent.com/4394842/79258136-fccb7400-7e8a-11ea-9002-356aec27179a.png">

Page externe (demo)
<img width="1173" alt="Screen Shot 2020-04-14 at 19 57 19" src="https://user-images.githubusercontent.com/4394842/79258165-05bc4580-7e8b-11ea-8dbe-f99d6d6e3128.png">
