### PR TITLE
Ajoute des warns disponible depuis Scala 2.13.

### DIFF
--- a/app/controllers/CSVImportController.scala
+++ b/app/controllers/CSVImportController.scala
@@ -103,7 +103,7 @@ case class CSVImportController @Inject() (
     val multiGroupUserEmails = groups
       .filterNot(_.doNotInsert)
       .flatMap(group => group.users.map(user => (group.group.id, user.user.email)))
-      .groupBy { case (groupId, userEmail) => userEmail }
+      .groupBy { case (_, userEmail) => userEmail }
       .collect { case (userEmail, groups) if groups.size > 1 => userEmail }
       .toSet
     groups.map(group => augmentUserGroupInformation(group, multiGroupUserEmails))

--- a/app/helper/TwirlImports.scala
+++ b/app/helper/TwirlImports.scala
@@ -1,5 +1,7 @@
 package helper
 
+import scala.language.implicitConversions
+
 object TwirlImports {
 
   /** This fixes the fact that a lot of twirl helpers take `(Symbol, String)` and

--- a/app/serializers/Anorm.scala
+++ b/app/serializers/Anorm.scala
@@ -15,7 +15,7 @@ object Anorm {
 
   implicit val fieldsMapStringParser: anorm.Column[Map[String, String]] =
     nonNull { (value, meta) =>
-      val MetaDataItem(qualified, nullable, clazz) = meta
+      val MetaDataItem(qualified, _, _) = meta
       value match {
         case json: org.postgresql.util.PGobject =>
           Right(Json.parse(json.getValue).as[Map[String, String]])
@@ -32,7 +32,7 @@ object Anorm {
 
   implicit val fieldsMapLongParser: anorm.Column[Map[String, Long]] =
     nonNull { (value, meta) =>
-      val MetaDataItem(qualified, nullable, clazz) = meta
+      val MetaDataItem(qualified, _, _) = meta
       value match {
         case json: org.postgresql.util.PGobject =>
           Right(Json.parse(json.getValue).as[Map[String, Long]])
@@ -55,7 +55,7 @@ object Anorm {
 
   implicit val fieldsMapUUIDParser: anorm.Column[Map[UUID, String]] =
     nonNull { (value, meta) =>
-      val MetaDataItem(qualified, nullable, clazz) = meta
+      val MetaDataItem(qualified, _, _) = meta
       value match {
         case json: org.postgresql.util.PGobject =>
           Right(convertStringMapToUUIDMap(Json.parse(json.getValue).as[Map[String, String]]))

--- a/app/services/ApplicationService.scala
+++ b/app/services/ApplicationService.scala
@@ -28,7 +28,7 @@ class ApplicationService @Inject() (
 
   implicit val answerListParser: anorm.Column[List[Answer]] =
     nonNull { (value, meta) =>
-      val MetaDataItem(qualified, nullable, clazz) = meta
+      val MetaDataItem(qualified, _, _) = meta
       value match {
         case json: org.postgresql.util.PGobject =>
           Right(Json.parse(json.getValue).as[List[Answer]])

--- a/app/services/EventService.scala
+++ b/app/services/EventService.scala
@@ -83,7 +83,7 @@ class EventService @Inject() (db: Database) {
     }
   }
 
-  private def addEvent(event: Event): Unit =
+  private def addEvent(event: Event): Boolean =
     db.withConnection { implicit connection =>
       SQL"""
           INSERT INTO event VALUES (

--- a/app/services/UserGroupService.scala
+++ b/app/services/UserGroupService.scala
@@ -111,7 +111,7 @@ class UserGroupService @Inject() (
     SQL"SELECT * FROM user_group WHERE name = $groupName".as(simpleUserGroup.singleOpt)
   }
 
-  def deleteById(groupId: UUID): Unit = db.withConnection { implicit connection =>
+  def deleteById(groupId: UUID): Boolean = db.withConnection { implicit connection =>
     SQL"""DELETE FROM "user_group" WHERE id = $groupId::uuid""".execute()
   }
 

--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -116,7 +116,7 @@ class UserService @Inject() (
     }.toList ++ (User.admins.filter(user => lowerCaseEmails.contains(user.email.toLowerCase)))
   }
 
-  def deleteById(userId: UUID): Unit = db.withTransaction { implicit connection =>
+  def deleteById(userId: UUID): Boolean = db.withTransaction { implicit connection =>
     SQL"""DELETE FROM "user" WHERE id = ${userId}::uuid""".execute()
   }
 

--- a/app/tasks/RemoveExpiredFilesTask.scala
+++ b/app/tasks/RemoveExpiredFilesTask.scala
@@ -39,7 +39,7 @@ class RemoveExpiredFilesTask @Inject() (
           val instant = Files.getLastModifiedTime(file.toPath).toInstant
           instant.plus(filesExpirationInDays.toLong + 1, DAYS).isBefore(Instant.now())
         }
-      fileToDelete.forall(_.delete())
+      fileToDelete.foreach(_.delete())
     }
   }
 }

--- a/app/views/showCGU.scala.html
+++ b/app/views/showCGU.scala.html
@@ -1,6 +1,6 @@
 @import models._
 @import _root_.helper.MDLForms._
-@(user: User, currentUserRights: Authorization.UserRights)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader, messagesProvider: MessagesProvider)
+@(user: User, currentUserRights: Authorization.UserRights)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, request: RequestHeader)
 
 @main(user, currentUserRights)("Conditions générales d’utilisations")  {
 <style>

--- a/build.sbt
+++ b/build.sbt
@@ -18,14 +18,48 @@ scalaVersion := "2.13.1"
 
 // https://docs.scala-lang.org/overviews/compiler-options/index.html
 scalacOptions ++= Seq(
+  "-feature",
   "-deprecation",
   "-unchecked",
-  "-Xlint:adapted-args,nullary-unit,inaccessible,nullary-override,infer-any,missing-interpolator,private-shadow,type-parameter-shadow,poly-implicit-overload,option-implicit,package-object-classes,unused",
-  "-Ywarn-dead-code",
-  "-Ywarn-numeric-widen"
+  "-Xlint:adapted-args",
+  "-Xlint:nullary-unit",
+  "-Xlint:inaccessible",
+  "-Xlint:nullary-override",
+  "-Xlint:infer-any",
+  "-Xlint:missing-interpolator",
+  "-Xlint:doc-detached",
+  "-Xlint:private-shadow",
+  "-Xlint:type-parameter-shadow",
+  "-Xlint:poly-implicit-overload",
+  "-Xlint:option-implicit",
+  "-Xlint:delayedinit-select",
+  "-Xlint:package-object-classes",
+  "-Xlint:stars-align",
+  "-Xlint:constant",
+  // Note: -Xlint:unused cannot work with twirl
+  // "-Xlint:unused",
+  "-Xlint:nonlocal-return",
+  "-Xlint:implicit-not-found",
+  "-Xlint:serial",
+  "-Xlint:valpattern",
+  "-Xlint:eta-zero",
+  "-Xlint:eta-sam",
+  "-Xlint:deprecation",
+  "-Wdead-code",
+  "-Wextra-implicit",
+  "-Wmacros:before",
+  "-Wnumeric-widen",
+  "-Woctal-literal",
+  // "-Wself-implicit", // Warns about too much useful constructs
+  // Note: -Wunused:imports cannot work with twirl
+  // "-Wunused:imports",
+  "-Wunused:patvars",
+  "-Wunused:privates",
+  "-Wunused:locals",
+  // "-Wunused:explicits", TODO: lot of warnings, enable later
+  "-Wunused:implicits",
+  "-Wvalue-discard",
 )
-
-//libraryDependencies += filters
 
 libraryDependencies ++= Seq(
   ws,


### PR DESCRIPTION
* La liste des warns est plus lisible.
* La liste des warns est calquée sur la liste dans la documentation.
* Supprime le warn "unused import" car il est incompatible avec twirl (même en utilisant sbt-silencer).
