### PR TITLE
Update scalafmt to 2.5

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,10 @@
-version = "2.4.2"
+version = "2.5.3"
 maxColumn = 100
 spaces.afterKeywordBeforeParen = true
 newlines.alwaysBeforeTopLevelStatements = true
+newlines.topLevelStatements = [before, after]
+trailingCommas = preserve
+rewrite.redundantBraces.generalExpressions = false
 
 rewrite.rules = [
   AvoidInfix

--- a/app/actions/LoginAction.scala
+++ b/app/actions/LoginAction.scala
@@ -198,8 +198,8 @@ class LoginAction @Inject() (
         .flashing("error" -> message)
     )
 
-  private def redirectToHomeWithEmailSendbackButton[A](email: String, message: String)(
-      implicit request: Request[A]
+  private def redirectToHomeWithEmailSendbackButton[A](email: String, message: String)(implicit
+      request: Request[A]
   ) =
     Left(
       TemporaryRedirect(routes.HomeController.index.url)
@@ -223,4 +223,5 @@ class LoginAction @Inject() (
       .get("userId")
       .flatMap(UUIDHelper.fromString)
       .flatMap(id => userService.byId(id, true))
+
 }

--- a/app/controllers/ApiController.scala
+++ b/app/controllers/ApiController.scala
@@ -60,62 +60,63 @@ case class ApiController @Inject() (
     }
   }
 
-  def franceServiceDeployment: Action[AnyContent] = loginAction.async { implicit request =>
-    asUserWithAuthorization(Authorization.isAdminOrObserver) { () =>
-      DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
-    } { () =>
-      val userGroups = userGroupService.allGroups.filter(
-        _.organisationSetOrDeducted.exists(_.id == Organisation.franceServicesId)
-      )
-      val franceServiceInstances = organisationService.franceServiceInfos.instances
-      val doNotMatchTheseEmails =
-        franceServiceInstances
-          .flatMap(_.contactMail)
-          .groupBy(identity)
-          .filter(_._2.length > 1)
-          .keys
-          .toSet
-      val matches: List[(FranceServiceInstance, Option[UserGroup], Area)] =
-        franceServiceInstances
-          .map(instance =>
-            (
-              instance,
-              matchFranceServiceInstance(instance, userGroups, doNotMatchTheseEmails),
-              Area.fromInseeCode(instance.departementCode.code).getOrElse(Area.notApplicable)
+  def franceServiceDeployment: Action[AnyContent] =
+    loginAction.async { implicit request =>
+      asUserWithAuthorization(Authorization.isAdminOrObserver) { () =>
+        DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
+      } { () =>
+        val userGroups = userGroupService.allGroups.filter(
+          _.organisationSetOrDeducted.exists(_.id == Organisation.franceServicesId)
+        )
+        val franceServiceInstances = organisationService.franceServiceInfos.instances
+        val doNotMatchTheseEmails =
+          franceServiceInstances
+            .flatMap(_.contactMail)
+            .groupBy(identity)
+            .filter(_._2.length > 1)
+            .keys
+            .toSet
+        val matches: List[(FranceServiceInstance, Option[UserGroup], Area)] =
+          franceServiceInstances
+            .map(instance =>
+              (
+                instance,
+                matchFranceServiceInstance(instance, userGroups, doNotMatchTheseEmails),
+                Area.fromInseeCode(instance.departementCode.code).getOrElse(Area.notApplicable)
+              )
             )
-          )
-      val allGroupIds: List[UUID] = matches.flatMap(_._2).map(_.id)
-      val allUsers = userService.byGroupIds(allGroupIds)
-      val groupSizes: Map[UUID, Int] = allUsers
-        .flatMap(user => user.groupIds.map(groupId => (groupId, user)))
-        .groupBy(_._1) // Group by groupId
-        .map { case (groupId, users) => (groupId, users.size) }
-        .toMap
-      val data: List[FranceServiceInstanceLine] = matches
-        .map {
-          case (franceServiceInstance, groupOpt, area) =>
-            FranceServiceInstanceLine(
-              nomFranceService = franceServiceInstance.nomFranceService,
-              commune = franceServiceInstance.commune,
-              departementName = area.name,
-              departementCode = area.inseeCode,
-              matchedGroup = groupOpt.map(_.name),
-              groupSize = groupOpt.flatMap(group => groupSizes.get(group.id)).getOrElse(0),
-              departementIsDone = false,
-              contactMail = franceServiceInstance.contactMail,
-              phone = franceServiceInstance.phone
-            )
-        }
-        .groupBy(_.departementCode)
-        .flatMap {
-          case (_, sameDepartementLines) =>
-            val departementIsDone = sameDepartementLines.forall(_.groupSize >= 2)
-            sameDepartementLines.map(_.copy(departementIsDone = departementIsDone))
-        }
-        .toList
-        .sortBy(line => (line.departementCode, line.nomFranceService))
-      Future(Ok(Json.toJson(data)))
+        val allGroupIds: List[UUID] = matches.flatMap(_._2).map(_.id)
+        val allUsers = userService.byGroupIds(allGroupIds)
+        val groupSizes: Map[UUID, Int] = allUsers
+          .flatMap(user => user.groupIds.map(groupId => (groupId, user)))
+          .groupBy(_._1) // Group by groupId
+          .map { case (groupId, users) => (groupId, users.size) }
+          .toMap
+        val data: List[FranceServiceInstanceLine] = matches
+          .map {
+            case (franceServiceInstance, groupOpt, area) =>
+              FranceServiceInstanceLine(
+                nomFranceService = franceServiceInstance.nomFranceService,
+                commune = franceServiceInstance.commune,
+                departementName = area.name,
+                departementCode = area.inseeCode,
+                matchedGroup = groupOpt.map(_.name),
+                groupSize = groupOpt.flatMap(group => groupSizes.get(group.id)).getOrElse(0),
+                departementIsDone = false,
+                contactMail = franceServiceInstance.contactMail,
+                phone = franceServiceInstance.phone
+              )
+          }
+          .groupBy(_.departementCode)
+          .flatMap {
+            case (_, sameDepartementLines) =>
+              val departementIsDone = sameDepartementLines.forall(_.groupSize >= 2)
+              sameDepartementLines.map(_.copy(departementIsDone = departementIsDone))
+          }
+          .toList
+          .sortBy(line => (line.departementCode, line.nomFranceService))
+        Future(Ok(Json.toJson(data)))
+      }
     }
-  }
 
 }

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -90,24 +90,26 @@ case class ApplicationController @Inject() (
     Files.createDirectories(dir)
   }
 
-  private def applicationForm(currentUser: User) = Form(
-    mapping(
-      "subject" -> nonEmptyText.verifying(maxLength(150)),
-      "description" -> nonEmptyText,
-      "infos" -> FormsPlusMap.map(nonEmptyText.verifying(maxLength(30))),
-      "users" -> list(uuid).verifying("Vous devez sélectionner au moins une structure", _.nonEmpty),
-      "organismes" -> list(text),
-      "category" -> optional(text),
-      "selected-subject" -> optional(text),
-      "signature" -> (
-        if (currentUser.sharedAccount)
-          nonEmptyText.transform[Option[String]](Some.apply, _.getOrElse(""))
-        else ignored(None: Option[String])
-      ),
-      "mandatType" -> text,
-      "mandatDate" -> nonEmptyText
-    )(ApplicationFormData.apply)(ApplicationFormData.unapply)
-  )
+  private def applicationForm(currentUser: User) =
+    Form(
+      mapping(
+        "subject" -> nonEmptyText.verifying(maxLength(150)),
+        "description" -> nonEmptyText,
+        "infos" -> FormsPlusMap.map(nonEmptyText.verifying(maxLength(30))),
+        "users" -> list(uuid)
+          .verifying("Vous devez sélectionner au moins une structure", _.nonEmpty),
+        "organismes" -> list(text),
+        "category" -> optional(text),
+        "selected-subject" -> optional(text),
+        "signature" -> (
+          if (currentUser.sharedAccount)
+            nonEmptyText.transform[Option[String]](Some.apply, _.getOrElse(""))
+          else ignored(None: Option[String])
+        ),
+        "mandatType" -> text,
+        "mandatDate" -> nonEmptyText
+      )(ApplicationFormData.apply)(ApplicationFormData.unapply)
+    )
 
   private def fetchGroupsWithInstructors(
       areaId: UUID,
@@ -139,48 +141,50 @@ case class ApplicationController @Inject() (
       .flatMap(Area.fromId)
       .getOrElse(Area.all.head)
 
-  def create: Action[AnyContent] = loginAction.async { implicit request =>
-    eventService.log(ApplicationFormShowed, "Visualise le formulaire de création de demande")
-    fetchGroupsWithInstructors(currentArea.id, request.currentUser).map {
-      case (groupsOfAreaWithInstructor, instructorsOfGroups, coworkers) =>
-        val categories = organisationService.categories
-        Ok(
-          views.html.createApplication(request.currentUser, request.rights, currentArea)(
-            instructorsOfGroups,
-            groupsOfAreaWithInstructor,
-            coworkers,
-            readSharedAccountUserSignature(request.session),
-            canCreatePhoneMandat = (currentArea: Area) == (Area.calvados: Area),
-            categories,
-            applicationForm(request.currentUser)
-          )
-        )
-    }
-  }
-
-  def createSimplified: Action[AnyContent] = loginAction.async { implicit request =>
-    eventService
-      .log(ApplicationFormShowed, "Visualise le formulaire simplifié de création de demande")
-    fetchGroupsWithInstructors(currentArea.id, request.currentUser).map {
-      case (groupsOfAreaWithInstructor, instructorsOfGroups, coworkers) =>
-        val groupsOfAreaWithInstructorWithOrganisationSet = groupsOfAreaWithInstructor.filter({
-          userGroup => userGroup.organisationSetOrDeducted.nonEmpty
-        })
-        val categories = organisationService.categories
-        Ok(
-          views.html
-            .simplifiedCreateApplication(request.currentUser, request.rights, currentArea)(
+  def create: Action[AnyContent] =
+    loginAction.async { implicit request =>
+      eventService.log(ApplicationFormShowed, "Visualise le formulaire de création de demande")
+      fetchGroupsWithInstructors(currentArea.id, request.currentUser).map {
+        case (groupsOfAreaWithInstructor, instructorsOfGroups, coworkers) =>
+          val categories = organisationService.categories
+          Ok(
+            views.html.createApplication(request.currentUser, request.rights, currentArea)(
               instructorsOfGroups,
-              groupsOfAreaWithInstructorWithOrganisationSet,
+              groupsOfAreaWithInstructor,
               coworkers,
               readSharedAccountUserSignature(request.session),
+              canCreatePhoneMandat = (currentArea: Area) == (Area.calvados: Area),
               categories,
-              None,
               applicationForm(request.currentUser)
             )
-        )
+          )
+      }
     }
-  }
+
+  def createSimplified: Action[AnyContent] =
+    loginAction.async { implicit request =>
+      eventService
+        .log(ApplicationFormShowed, "Visualise le formulaire simplifié de création de demande")
+      fetchGroupsWithInstructors(currentArea.id, request.currentUser).map {
+        case (groupsOfAreaWithInstructor, instructorsOfGroups, coworkers) =>
+          val groupsOfAreaWithInstructorWithOrganisationSet = groupsOfAreaWithInstructor.filter({
+            userGroup => userGroup.organisationSetOrDeducted.nonEmpty
+          })
+          val categories = organisationService.categories
+          Ok(
+            views.html
+              .simplifiedCreateApplication(request.currentUser, request.rights, currentArea)(
+                instructorsOfGroups,
+                groupsOfAreaWithInstructorWithOrganisationSet,
+                coworkers,
+                readSharedAccountUserSignature(request.session),
+                categories,
+                None,
+                applicationForm(request.currentUser)
+              )
+          )
+      }
+    }
 
   def createPost: Action[AnyContent] = createPostBis(false)
 
@@ -210,121 +214,122 @@ case class ApplicationController @Inject() (
       s"${capitalizedUserName} ${contexts.mkString(",")}"
   }
 
-  private def createPostBis(simplified: Boolean) = loginAction.async { implicit request =>
-    val form = applicationForm(request.currentUser).bindFromRequest
-    val applicationId = AttachmentHelper.retrieveOrGenerateApplicationId(form.data)
-    val (pendingAttachments, newAttachments) =
-      AttachmentHelper.computeStoreAndRemovePendingAndNewApplicationAttachment(
-        applicationId,
-        form.data,
-        computeAttachmentsToStore(request),
-        filesPath
-      )
-    form.fold(
-      formWithErrors =>
-        // binding failure, you retrieve the form containing errors:
-        fetchGroupsWithInstructors(currentArea.id, request.currentUser).map {
-          case (groupsOfAreaWithInstructor, instructorsOfGroups, coworkers) =>
-            eventService.log(
-              ApplicationCreationInvalid,
-              s"L'utilisateur essaie de créer une demande invalide ${formWithErrors.errors.map(_.message)}"
-            )
-
-            if (simplified) {
-              val categories = organisationService.categories
-              val groupsOfAreaWithInstructorWithOrganisationSet =
-                groupsOfAreaWithInstructor.filter(_.organisationSetOrDeducted.nonEmpty)
-              BadRequest(
-                views.html.simplifiedCreateApplication(
-                  request.currentUser,
-                  request.rights,
-                  currentArea
-                )(
-                  instructorsOfGroups,
-                  groupsOfAreaWithInstructorWithOrganisationSet,
-                  coworkers,
-                  None,
-                  categories,
-                  formWithErrors("category").value,
-                  formWithErrors,
-                  pendingAttachments.keys ++ newAttachments.keys
-                )
+  private def createPostBis(simplified: Boolean) =
+    loginAction.async { implicit request =>
+      val form = applicationForm(request.currentUser).bindFromRequest
+      val applicationId = AttachmentHelper.retrieveOrGenerateApplicationId(form.data)
+      val (pendingAttachments, newAttachments) =
+        AttachmentHelper.computeStoreAndRemovePendingAndNewApplicationAttachment(
+          applicationId,
+          form.data,
+          computeAttachmentsToStore(request),
+          filesPath
+        )
+      form.fold(
+        formWithErrors =>
+          // binding failure, you retrieve the form containing errors:
+          fetchGroupsWithInstructors(currentArea.id, request.currentUser).map {
+            case (groupsOfAreaWithInstructor, instructorsOfGroups, coworkers) =>
+              eventService.log(
+                ApplicationCreationInvalid,
+                s"L'utilisateur essaie de créer une demande invalide ${formWithErrors.errors.map(_.message)}"
               )
-            } else {
-              BadRequest(
-                views.html
-                  .createApplication(request.currentUser, request.rights, currentArea)(
+
+              if (simplified) {
+                val categories = organisationService.categories
+                val groupsOfAreaWithInstructorWithOrganisationSet =
+                  groupsOfAreaWithInstructor.filter(_.organisationSetOrDeducted.nonEmpty)
+                BadRequest(
+                  views.html.simplifiedCreateApplication(
+                    request.currentUser,
+                    request.rights,
+                    currentArea
+                  )(
                     instructorsOfGroups,
-                    groupsOfAreaWithInstructor,
+                    groupsOfAreaWithInstructorWithOrganisationSet,
                     coworkers,
                     None,
-                    canCreatePhoneMandat = (currentArea: Area) == (Area.calvados: Area),
-                    organisationService.categories,
+                    categories,
+                    formWithErrors("category").value,
                     formWithErrors,
                     pendingAttachments.keys ++ newAttachments.keys
                   )
+                )
+              } else {
+                BadRequest(
+                  views.html
+                    .createApplication(request.currentUser, request.rights, currentArea)(
+                      instructorsOfGroups,
+                      groupsOfAreaWithInstructor,
+                      coworkers,
+                      None,
+                      canCreatePhoneMandat = (currentArea: Area) == (Area.calvados: Area),
+                      organisationService.categories,
+                      formWithErrors,
+                      pendingAttachments.keys ++ newAttachments.keys
+                    )
+                )
+              }
+          },
+        applicationData =>
+          Future {
+            // Note: we will deprecate .currentArea as a variable stored in the cookies
+            val currentAreaId: UUID = currentArea.id
+            val invitedUsers: Map[UUID, String] = applicationData.users.flatMap { id =>
+              userService.byId(id).map(user => id -> contextualizedUserName(user, currentAreaId))
+            }.toMap
+
+            val description: String =
+              applicationData.signature
+                .fold(applicationData.description)(signature =>
+                  applicationData.description + "\n\n" + signature
+                )
+            val application = Application(
+              applicationId,
+              Time.nowParis(),
+              contextualizedUserName(request.currentUser, currentAreaId),
+              request.currentUser.id,
+              applicationData.subject,
+              description,
+              applicationData.infos,
+              invitedUsers,
+              currentArea.id,
+              false,
+              hasSelectedSubject =
+                applicationData.selectedSubject.contains[String](applicationData.subject),
+              category = applicationData.category,
+              files = newAttachments ++ pendingAttachments,
+              mandatType = DataModel.Application.MandatType
+                .dataModelDeserialization(applicationData.mandatType),
+              mandatDate = Some(applicationData.mandatDate)
+            )
+            if (applicationService.createApplication(application)) {
+              notificationsService.newApplication(application)
+              eventService.log(
+                ApplicationCreated,
+                s"La demande ${application.id} a été créée",
+                Some(application)
+              )
+              Redirect(routes.ApplicationController.myApplications())
+                .withSession(
+                  applicationData.signature.fold(removeSharedAccountUserSignature(request.session))(
+                    signature => saveSharedAccountUserSignature(request.session, signature)
+                  )
+                )
+                .flashing("success" -> "Votre demande a bien été envoyée")
+            } else {
+              eventService.log(
+                ApplicationCreationError,
+                s"La demande ${application.id} n'a pas pu être créée",
+                Some(application)
+              )
+              InternalServerError(
+                "Erreur Interne: Votre demande n'a pas pu être envoyée. Merci de réessayer ou de contacter l'administrateur"
               )
             }
-        },
-      applicationData =>
-        Future {
-          // Note: we will deprecate .currentArea as a variable stored in the cookies
-          val currentAreaId: UUID = currentArea.id
-          val invitedUsers: Map[UUID, String] = applicationData.users.flatMap { id =>
-            userService.byId(id).map(user => id -> contextualizedUserName(user, currentAreaId))
-          }.toMap
-
-          val description: String =
-            applicationData.signature
-              .fold(applicationData.description)(signature =>
-                applicationData.description + "\n\n" + signature
-              )
-          val application = Application(
-            applicationId,
-            Time.nowParis(),
-            contextualizedUserName(request.currentUser, currentAreaId),
-            request.currentUser.id,
-            applicationData.subject,
-            description,
-            applicationData.infos,
-            invitedUsers,
-            currentArea.id,
-            false,
-            hasSelectedSubject =
-              applicationData.selectedSubject.contains[String](applicationData.subject),
-            category = applicationData.category,
-            files = newAttachments ++ pendingAttachments,
-            mandatType =
-              DataModel.Application.MandatType.dataModelDeserialization(applicationData.mandatType),
-            mandatDate = Some(applicationData.mandatDate)
-          )
-          if (applicationService.createApplication(application)) {
-            notificationsService.newApplication(application)
-            eventService.log(
-              ApplicationCreated,
-              s"La demande ${application.id} a été créée",
-              Some(application)
-            )
-            Redirect(routes.ApplicationController.myApplications())
-              .withSession(
-                applicationData.signature.fold(removeSharedAccountUserSignature(request.session))(
-                  signature => saveSharedAccountUserSignature(request.session, signature)
-                )
-              )
-              .flashing("success" -> "Votre demande a bien été envoyée")
-          } else {
-            eventService.log(
-              ApplicationCreationError,
-              s"La demande ${application.id} n'a pas pu être créée",
-              Some(application)
-            )
-            InternalServerError(
-              "Erreur Interne: Votre demande n'a pas pu être envoyée. Merci de réessayer ou de contacter l'administrateur"
-            )
           }
-        }
-    )
-  }
+      )
+    }
 
   private def computeAttachmentsToStore(
       request: RequestWithUserData[AnyContent]
@@ -355,55 +360,57 @@ case class ApplicationController @Inject() (
         Future(Nil)
     }
 
-  def all(areaId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    (request.currentUser.admin, request.currentUser.groupAdmin) match {
-      case (false, false) =>
-        eventService.log(
-          AllApplicationsUnauthorized,
-          "L'utilisateur n'a pas de droit d'afficher toutes les demandes"
-        )
-        Future(
-          Unauthorized(
-            s"Vous n'avez pas les droits suffisants pour voir cette page. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-          )
-        )
-      case _ =>
-        val area = if (areaId == Area.allArea.id) None else Area.fromId(areaId)
-        allApplicationVisibleByUserAdmin(request.currentUser, area).map { applications =>
+  def all(areaId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      (request.currentUser.admin, request.currentUser.groupAdmin) match {
+        case (false, false) =>
           eventService.log(
-            AllApplicationsShowed,
-            s"Visualise la liste des applications de $areaId - taille = ${applications.size}"
+            AllApplicationsUnauthorized,
+            "L'utilisateur n'a pas de droit d'afficher toutes les demandes"
           )
-          Ok(
-            views.html
-              .allApplications(request.currentUser, request.rights)(
-                applications,
-                area.getOrElse(Area.allArea)
-              )
+          Future(
+            Unauthorized(
+              s"Vous n'avez pas les droits suffisants pour voir cette page. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
+            )
           )
-        }
+        case _ =>
+          val area = if (areaId == Area.allArea.id) None else Area.fromId(areaId)
+          allApplicationVisibleByUserAdmin(request.currentUser, area).map { applications =>
+            eventService.log(
+              AllApplicationsShowed,
+              s"Visualise la liste des applications de $areaId - taille = ${applications.size}"
+            )
+            Ok(
+              views.html
+                .allApplications(request.currentUser, request.rights)(
+                  applications,
+                  area.getOrElse(Area.allArea)
+                )
+            )
+          }
+      }
     }
-  }
 
-  def myApplications: Action[AnyContent] = loginAction { implicit request =>
-    val myApplications = applicationService.allOpenOrRecentForUserId(
-      request.currentUser.id,
-      request.currentUser.admin,
-      Time.nowParis()
-    )
-    val (myClosedApplications, myOpenApplications) = myApplications.partition(_.closed)
-
-    eventService.log(
-      MyApplicationsShowed,
-      s"Visualise la liste des applications : open=${myOpenApplications.size}/closed=${myClosedApplications.size}"
-    )
-    Ok(
-      views.html.myApplications(request.currentUser, request.rights)(
-        myOpenApplications,
-        myClosedApplications
+  def myApplications: Action[AnyContent] =
+    loginAction { implicit request =>
+      val myApplications = applicationService.allOpenOrRecentForUserId(
+        request.currentUser.id,
+        request.currentUser.admin,
+        Time.nowParis()
       )
-    )
-  }
+      val (myClosedApplications, myOpenApplications) = myApplications.partition(_.closed)
+
+      eventService.log(
+        MyApplicationsShowed,
+        s"Visualise la liste des applications : open=${myOpenApplications.size}/closed=${myClosedApplications.size}"
+      )
+      Ok(
+        views.html.myApplications(request.currentUser, request.rights)(
+          myOpenApplications,
+          myClosedApplications
+        )
+      )
+    }
 
   private def statsAggregates(
       applications: List[Application],
@@ -453,8 +460,8 @@ case class ApplicationController @Inject() (
       groupIds: List[UUID],
       creationMinDate: LocalDate,
       creationMaxDate: LocalDate
-  )(
-      implicit webJarsUtil: org.webjars.play.WebJarsUtil,
+  )(implicit
+      webJarsUtil: org.webjars.play.WebJarsUtil,
       request: RequestWithUserData[A]
   ): Future[Html] = {
 
@@ -527,120 +534,124 @@ case class ApplicationController @Inject() (
   }
 
   // A `def` for the LocalDate.now()
-  private def statsForm = Form(
-    tuple(
-      "areas" -> default(list(uuid), List()),
-      "organisations" -> default(list(of[Organisation.Id]), List()),
-      "groups" -> default(list(uuid), List()),
-      "creationMinDate" -> default(localDate, LocalDate.of(2017, 12, 15)),
-      "creationMaxDate" -> default(localDate, LocalDate.now())
-    )
-  )
-
-  def stats: Action[AnyContent] = loginAction.async { implicit request =>
-    // TODO: remove `.get`
-    val (areaIds, organisationIds, groupIds, creationMinDate, creationMaxDate) =
-      statsForm.bindFromRequest.value.get
-
-    val observableOrganisationIds = if (Authorization.isAdmin(request.rights)) {
-      organisationIds
-    } else {
-      organisationIds.filter(id => Authorization.canObserveOrganisation(id)(request.rights))
-    }
-
-    val observableGroupIds = if (Authorization.isAdmin(request.rights)) {
-      groupIds
-    } else {
-      groupIds.intersect(request.currentUser.groupIds)
-    }
-
-    val cacheKey =
-      (Authorization.isAdmin(request.rights).toString +
-        ".stats." +
-        Hash.sha256(
-          areaIds.toString + observableOrganisationIds.toString + observableGroupIds.toString +
-            creationMinDate.toString + creationMaxDate.toString
-        ))
-
-    cache
-      .getOrElseUpdate[Html](cacheKey, 1.hours)(
-        generateStats(
-          areaIds,
-          observableOrganisationIds,
-          observableGroupIds,
-          creationMinDate,
-          creationMaxDate
-        )
+  private def statsForm =
+    Form(
+      tuple(
+        "areas" -> default(list(uuid), List()),
+        "organisations" -> default(list(of[Organisation.Id]), List()),
+        "groups" -> default(list(uuid), List()),
+        "creationMinDate" -> default(localDate, LocalDate.of(2017, 12, 15)),
+        "creationMaxDate" -> default(localDate, LocalDate.now())
       )
-      .map { html =>
-        eventService.log(StatsShowed, "Visualise les stats")
-        Ok(
-          views.html.stats.page(request.currentUser, request.rights)(
-            html,
-            List(),
+    )
+
+  def stats: Action[AnyContent] =
+    loginAction.async { implicit request =>
+      // TODO: remove `.get`
+      val (areaIds, organisationIds, groupIds, creationMinDate, creationMaxDate) =
+        statsForm.bindFromRequest.value.get
+
+      val observableOrganisationIds = if (Authorization.isAdmin(request.rights)) {
+        organisationIds
+      } else {
+        organisationIds.filter(id => Authorization.canObserveOrganisation(id)(request.rights))
+      }
+
+      val observableGroupIds = if (Authorization.isAdmin(request.rights)) {
+        groupIds
+      } else {
+        groupIds.intersect(request.currentUser.groupIds)
+      }
+
+      val cacheKey =
+        (Authorization.isAdmin(request.rights).toString +
+          ".stats." +
+          Hash.sha256(
+            areaIds.toString + observableOrganisationIds.toString + observableGroupIds.toString +
+              creationMinDate.toString + creationMaxDate.toString
+          ))
+
+      cache
+        .getOrElseUpdate[Html](cacheKey, 1.hours)(
+          generateStats(
             areaIds,
-            organisationIds,
-            groupIds,
+            observableOrganisationIds,
+            observableGroupIds,
             creationMinDate,
             creationMaxDate
           )
         )
-      }
-  }
-
-  def allAs(userId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    val userOption = userService.byId(userId)
-    (request.currentUser.admin, userOption) match {
-      case (false, Some(user)) =>
-        eventService.log(
-          AllAsUnauthorized,
-          s"L'utilisateur n'a pas de droit d'afficher la vue de l'utilisateur $userId",
-          user = Some(user)
-        )
-        Future(
-          Unauthorized(
-            s"Vous n'avez pas le droit de faire ça, vous n'êtes pas administrateur. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-          )
-        )
-      case (true, Some(user)) if user.admin =>
-        eventService.log(
-          AllAsUnauthorized,
-          s"L'utilisateur n'a pas de droit d'afficher la vue de l'utilisateur admin $userId",
-          user = Some(user)
-        )
-        Future(
-          Unauthorized(
-            s"Vous n'avez pas le droit de faire ça avec un compte administrateur. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-          )
-        )
-      case (true, Some(user)) if request.currentUser.areas.intersect(user.areas).nonEmpty =>
-        LoginAction.readUserRights(user).map { userRights =>
-          val currentUserId = user.id
-          val applicationsFromTheArea = List[Application]()
-          eventService
-            .log(AllAsShowed, s"Visualise la vue de l'utilisateur $userId", user = Some(user))
-          // Bug To Fix
+        .map { html =>
+          eventService.log(StatsShowed, "Visualise les stats")
           Ok(
-            views.html.myApplications(user, userRights)(
-              applicationService.allForCreatorUserId(currentUserId, request.currentUser.admin),
-              applicationService.allForInvitedUserId(currentUserId, request.currentUser.admin),
-              applicationsFromTheArea
+            views.html.stats.page(request.currentUser, request.rights)(
+              html,
+              List(),
+              areaIds,
+              organisationIds,
+              groupIds,
+              creationMinDate,
+              creationMaxDate
             )
           )
         }
-      case _ =>
-        eventService.log(AllAsNotFound, s"L'utilisateur $userId n'existe pas")
-        Future(
-          BadRequest(
-            s"L'utilisateur n'existe pas ou vous n'avez pas le droit d'accéder à cette page. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-          )
-        )
     }
-  }
 
-  def showExportMyApplicationsCSV: Action[AnyContent] = loginAction { implicit request =>
-    Ok(views.html.CSVExport(request.currentUser, request.rights))
-  }
+  def allAs(userId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      val userOption = userService.byId(userId)
+      (request.currentUser.admin, userOption) match {
+        case (false, Some(user)) =>
+          eventService.log(
+            AllAsUnauthorized,
+            s"L'utilisateur n'a pas de droit d'afficher la vue de l'utilisateur $userId",
+            user = Some(user)
+          )
+          Future(
+            Unauthorized(
+              s"Vous n'avez pas le droit de faire ça, vous n'êtes pas administrateur. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
+            )
+          )
+        case (true, Some(user)) if user.admin =>
+          eventService.log(
+            AllAsUnauthorized,
+            s"L'utilisateur n'a pas de droit d'afficher la vue de l'utilisateur admin $userId",
+            user = Some(user)
+          )
+          Future(
+            Unauthorized(
+              s"Vous n'avez pas le droit de faire ça avec un compte administrateur. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
+            )
+          )
+        case (true, Some(user)) if request.currentUser.areas.intersect(user.areas).nonEmpty =>
+          LoginAction.readUserRights(user).map { userRights =>
+            val currentUserId = user.id
+            val applicationsFromTheArea = List[Application]()
+            eventService
+              .log(AllAsShowed, s"Visualise la vue de l'utilisateur $userId", user = Some(user))
+            // Bug To Fix
+            Ok(
+              views.html.myApplications(user, userRights)(
+                applicationService.allForCreatorUserId(currentUserId, request.currentUser.admin),
+                applicationService.allForInvitedUserId(currentUserId, request.currentUser.admin),
+                applicationsFromTheArea
+              )
+            )
+          }
+        case _ =>
+          eventService.log(AllAsNotFound, s"L'utilisateur $userId n'existe pas")
+          Future(
+            BadRequest(
+              s"L'utilisateur n'existe pas ou vous n'avez pas le droit d'accéder à cette page. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
+            )
+          )
+      }
+    }
+
+  def showExportMyApplicationsCSV: Action[AnyContent] =
+    loginAction { implicit request =>
+      Ok(views.html.CSVExport(request.currentUser, request.rights))
+    }
 
   private def applicationsToCSV(applications: List[Application]): String = {
     val usersId = applications.flatMap(_.invitedUsers.keys) ++ applications.map(_.creatorUserId)
@@ -698,56 +709,61 @@ case class ApplicationController @Inject() (
     (List(headers) ++ applications.map(applicationToCSV)).mkString("\n")
   }
 
-  def myCSV: Action[AnyContent] = loginAction { implicit request =>
-    val currentDate = Time.nowParis()
-    val exportedApplications = applicationService
-      .allOpenOrRecentForUserId(request.currentUser.id, request.currentUser.admin, currentDate)
+  def myCSV: Action[AnyContent] =
+    loginAction { implicit request =>
+      val currentDate = Time.nowParis()
+      val exportedApplications = applicationService
+        .allOpenOrRecentForUserId(request.currentUser.id, request.currentUser.admin, currentDate)
 
-    val date = Time.formatPatternFr(currentDate, "YYY-MM-dd-HH'h'mm")
-    val csvContent = applicationsToCSV(exportedApplications)
-
-    eventService.log(MyCSVShowed, s"Visualise le CSV de mes demandes")
-    Ok(csvContent)
-      .withHeaders("Content-Disposition" -> s"""attachment; filename="aplus-demandes-$date.csv"""")
-      .as("text/csv")
-  }
-
-  def allCSV(areaId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    val area = if (areaId == Area.allArea.id) None else Area.fromId(areaId)
-    val exportedApplicationsFuture =
-      if (request.currentUser.admin || request.currentUser.groupAdmin) {
-        allApplicationVisibleByUserAdmin(request.currentUser, area)
-      } else {
-        Future(Nil)
-      }
-
-    exportedApplicationsFuture.map { exportedApplications =>
-      val date = Time.formatPatternFr(Time.nowParis(), "YYY-MM-dd-HH'h'mm")
+      val date = Time.formatPatternFr(currentDate, "YYY-MM-dd-HH'h'mm")
       val csvContent = applicationsToCSV(exportedApplications)
 
-      eventService.log(AllCSVShowed, s"Visualise un CSV pour la zone ${area}")
-      val filenameAreaPart: String = area.map(_.name.stripSpecialChars).getOrElse("tous")
+      eventService.log(MyCSVShowed, s"Visualise le CSV de mes demandes")
       Ok(csvContent)
         .withHeaders(
-          "Content-Disposition" -> s"""attachment; filename="aplus-demandes-$date-${filenameAreaPart}.csv""""
+          "Content-Disposition" -> s"""attachment; filename="aplus-demandes-$date.csv""""
         )
         .as("text/csv")
     }
-  }
 
-  private def answerForm(currentUser: User) = Form(
-    mapping(
-      "message" -> nonEmptyText,
-      "irrelevant" -> boolean,
-      "infos" -> FormsPlusMap.map(nonEmptyText.verifying(maxLength(30))),
-      "privateToHelpers" -> boolean,
-      "signature" -> (
-        if (currentUser.sharedAccount)
-          nonEmptyText.transform[Option[String]](Some.apply, _.getOrElse(""))
-        else ignored(None: Option[String])
-      )
-    )(AnswerFormData.apply)(AnswerFormData.unapply)
-  )
+  def allCSV(areaId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      val area = if (areaId == Area.allArea.id) None else Area.fromId(areaId)
+      val exportedApplicationsFuture =
+        if (request.currentUser.admin || request.currentUser.groupAdmin) {
+          allApplicationVisibleByUserAdmin(request.currentUser, area)
+        } else {
+          Future(Nil)
+        }
+
+      exportedApplicationsFuture.map { exportedApplications =>
+        val date = Time.formatPatternFr(Time.nowParis(), "YYY-MM-dd-HH'h'mm")
+        val csvContent = applicationsToCSV(exportedApplications)
+
+        eventService.log(AllCSVShowed, s"Visualise un CSV pour la zone ${area}")
+        val filenameAreaPart: String = area.map(_.name.stripSpecialChars).getOrElse("tous")
+        Ok(csvContent)
+          .withHeaders(
+            "Content-Disposition" -> s"""attachment; filename="aplus-demandes-$date-${filenameAreaPart}.csv""""
+          )
+          .as("text/csv")
+      }
+    }
+
+  private def answerForm(currentUser: User) =
+    Form(
+      mapping(
+        "message" -> nonEmptyText,
+        "irrelevant" -> boolean,
+        "infos" -> FormsPlusMap.map(nonEmptyText.verifying(maxLength(30))),
+        "privateToHelpers" -> boolean,
+        "signature" -> (
+          if (currentUser.sharedAccount)
+            nonEmptyText.transform[Option[String]](Some.apply, _.getOrElse(""))
+          else ignored(None: Option[String])
+        )
+      )(AnswerFormData.apply)(AnswerFormData.unapply)
+    )
 
   private def usersWhoCanBeInvitedOn[A](
       application: Application
@@ -771,30 +787,31 @@ case class ApplicationController @Inject() (
       )
     )
 
-  def show(id: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    withApplication(id) { application =>
-      usersWhoCanBeInvitedOn(application).map { usersWhoCanBeInvited =>
-        val groups = userGroupService
-          .byIds(usersWhoCanBeInvited.flatMap(_.groupIds))
-          .filter(_.areaIds.contains[UUID](application.area))
-        val groupsWithUsersThatCanBeInvited = groups.map { group =>
-          group -> usersWhoCanBeInvited.filter(_.groupIds.contains[UUID](group.id))
-        }
-        val openedTab = request.flash.get("opened-tab").getOrElse("answer")
-        eventService.log(ApplicationShowed, s"Demande $id consultée", Some(application))
-        Ok(
-          views.html.showApplication(request.currentUser, request.rights)(
-            groupsWithUsersThatCanBeInvited,
-            application,
-            answerForm(request.currentUser),
-            openedTab,
-            currentArea,
-            readSharedAccountUserSignature(request.session)
+  def show(id: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      withApplication(id) { application =>
+        usersWhoCanBeInvitedOn(application).map { usersWhoCanBeInvited =>
+          val groups = userGroupService
+            .byIds(usersWhoCanBeInvited.flatMap(_.groupIds))
+            .filter(_.areaIds.contains[UUID](application.area))
+          val groupsWithUsersThatCanBeInvited = groups.map { group =>
+            group -> usersWhoCanBeInvited.filter(_.groupIds.contains[UUID](group.id))
+          }
+          val openedTab = request.flash.get("opened-tab").getOrElse("answer")
+          eventService.log(ApplicationShowed, s"Demande $id consultée", Some(application))
+          Ok(
+            views.html.showApplication(request.currentUser, request.rights)(
+              groupsWithUsersThatCanBeInvited,
+              application,
+              answerForm(request.currentUser),
+              openedTab,
+              currentArea,
+              readSharedAccountUserSignature(request.session)
+            )
           )
-        )
+        }
       }
     }
-  }
 
   def answerFile(applicationId: UUID, answerId: UUID, filename: String): Action[AnyContent] =
     file(applicationId, Some(answerId), filename)
@@ -813,9 +830,15 @@ case class ApplicationController @Inject() (
                   FileOpened,
                   s"Le fichier de la réponse $answerId sur la demande $applicationId a été ouvert"
                 )
-                Future(Ok.sendPath(Paths.get(s"$filesPath/ans_$answerId-$filename"), true, {
-                  _: Path => Some(filename)
-                }))
+                Future(
+                  Ok.sendPath(
+                    Paths.get(s"$filesPath/ans_$answerId-$filename"),
+                    true,
+                    { _: Path =>
+                      Some(filename)
+                    }
+                  )
+                )
               case _ =>
                 eventService.log(
                   FileNotFound,
@@ -827,9 +850,15 @@ case class ApplicationController @Inject() (
             if (application.files.contains(filename)) {
               eventService
                 .log(FileOpened, s"Le fichier de la demande $applicationId a été ouvert")
-              Future(Ok.sendPath(Paths.get(s"$filesPath/app_$applicationId-$filename"), true, {
-                _: Path => Some(filename)
-              }))
+              Future(
+                Ok.sendPath(
+                  Paths.get(s"$filesPath/app_$applicationId-$filename"),
+                  true,
+                  { _: Path =>
+                    Some(filename)
+                  }
+                )
+              )
             } else {
               eventService.log(
                 FileNotFound,
@@ -852,73 +881,75 @@ case class ApplicationController @Inject() (
       }
     }
 
-  def answer(applicationId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    withApplication(applicationId) { application =>
-      val form = answerForm(request.currentUser).bindFromRequest
-      val answerId = AttachmentHelper.retrieveOrGenerateAnswerId(form.data)
-      val (pendingAttachments, newAttachments) =
-        AttachmentHelper.computeStoreAndRemovePendingAndNewAnswerAttachment(
-          answerId,
-          form.data,
-          computeAttachmentsToStore(request),
-          filesPath
-        )
-      form.fold(
-        formWithErrors => {
-          val error =
-            s"Erreur dans le formulaire de réponse (${formWithErrors.errors.map(_.message).mkString(", ")})."
-          eventService.log(AnswerNotCreated, s"$error")
-          Future(
-            Redirect(routes.ApplicationController.show(applicationId).withFragment("answer-error"))
-              .flashing("answer-error" -> error, "opened-tab" -> "anwser")
-          )
-        },
-        answerData => {
-          val currentAreaId = application.area
-          val message: String =
-            answerData.signature
-              .fold(answerData.message)(signature => answerData.message + "\n\n" + signature)
-          val answer = Answer(
+  def answer(applicationId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      withApplication(applicationId) { application =>
+        val form = answerForm(request.currentUser).bindFromRequest
+        val answerId = AttachmentHelper.retrieveOrGenerateAnswerId(form.data)
+        val (pendingAttachments, newAttachments) =
+          AttachmentHelper.computeStoreAndRemovePendingAndNewAnswerAttachment(
             answerId,
-            applicationId,
-            Time.nowParis(),
-            message,
-            request.currentUser.id,
-            contextualizedUserName(request.currentUser, currentAreaId),
-            Map(),
-            answerData.privateToHelpers == false,
-            answerData.applicationIsDeclaredIrrelevant,
-            Some(answerData.infos),
-            files = Some(newAttachments ++ pendingAttachments)
+            form.data,
+            computeAttachmentsToStore(request),
+            filesPath
           )
-          if (applicationService.add(applicationId, answer) == 1) {
-            eventService.log(
-              AnswerCreated,
-              s"La réponse ${answer.id} a été créée sur la demande $applicationId",
-              Some(application)
-            )
-            notificationsService.newAnswer(application, answer)
+        form.fold(
+          formWithErrors => {
+            val error =
+              s"Erreur dans le formulaire de réponse (${formWithErrors.errors.map(_.message).mkString(", ")})."
+            eventService.log(AnswerNotCreated, s"$error")
             Future(
-              Redirect(s"${routes.ApplicationController.show(applicationId)}#answer-${answer.id}")
-                .withSession(
-                  answerData.signature.fold(removeSharedAccountUserSignature(request.session))(
-                    signature => saveSharedAccountUserSignature(request.session, signature)
+              Redirect(
+                routes.ApplicationController.show(applicationId).withFragment("answer-error")
+              ).flashing("answer-error" -> error, "opened-tab" -> "anwser")
+            )
+          },
+          answerData => {
+            val currentAreaId = application.area
+            val message: String =
+              answerData.signature
+                .fold(answerData.message)(signature => answerData.message + "\n\n" + signature)
+            val answer = Answer(
+              answerId,
+              applicationId,
+              Time.nowParis(),
+              message,
+              request.currentUser.id,
+              contextualizedUserName(request.currentUser, currentAreaId),
+              Map(),
+              answerData.privateToHelpers == false,
+              answerData.applicationIsDeclaredIrrelevant,
+              Some(answerData.infos),
+              files = Some(newAttachments ++ pendingAttachments)
+            )
+            if (applicationService.add(applicationId, answer) == 1) {
+              eventService.log(
+                AnswerCreated,
+                s"La réponse ${answer.id} a été créée sur la demande $applicationId",
+                Some(application)
+              )
+              notificationsService.newAnswer(application, answer)
+              Future(
+                Redirect(s"${routes.ApplicationController.show(applicationId)}#answer-${answer.id}")
+                  .withSession(
+                    answerData.signature.fold(removeSharedAccountUserSignature(request.session))(
+                      signature => saveSharedAccountUserSignature(request.session, signature)
+                    )
                   )
-                )
-                .flashing("success" -> "Votre réponse a bien été envoyée")
-            )
-          } else {
-            eventService.log(
-              AnswerNotCreated,
-              s"La réponse ${answer.id} n'a pas été créée sur la demande $applicationId : problème BDD",
-              Some(application)
-            )
-            Future(InternalServerError("Votre réponse n'a pas pu être envoyée"))
+                  .flashing("success" -> "Votre réponse a bien été envoyée")
+              )
+            } else {
+              eventService.log(
+                AnswerNotCreated,
+                s"La réponse ${answer.id} n'a pas été créée sur la demande $applicationId : problème BDD",
+                Some(application)
+              )
+              Future(InternalServerError("Votre réponse n'a pas pu être envoyée"))
+            }
           }
-        }
-      )
+        )
+      }
     }
-  }
 
   private val inviteForm = Form(
     mapping(
@@ -928,65 +959,67 @@ case class ApplicationController @Inject() (
     )(InvitationData.apply)(InvitationData.unapply)
   )
 
-  def invite(applicationId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    withApplication(applicationId) { application =>
-      inviteForm.bindFromRequest.fold(
-        formWithErrors => {
-          val error =
-            s"Erreur dans le formulaire d'invitation (${formWithErrors.errors.map(_.message).mkString(", ")})."
-          eventService.log(InviteNotCreated, error)
-          Future(
-            Redirect(routes.ApplicationController.show(applicationId).withFragment("answer-error"))
-              .flashing("answer-error" -> error, "opened-tab" -> "invite")
-          )
-        },
-        inviteData => {
-          val currentAreaId = application.area
-          usersWhoCanBeInvitedOn(application).map {
-            usersWhoCanBeInvited =>
-              val invitedUsers: Map[UUID, String] = usersWhoCanBeInvited
-                .filter(user => inviteData.invitedUsers.contains[UUID](user.id))
-                .map(user => (user.id, contextualizedUserName(user, currentAreaId)))
-                .toMap
+  def invite(applicationId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      withApplication(applicationId) { application =>
+        inviteForm.bindFromRequest.fold(
+          formWithErrors => {
+            val error =
+              s"Erreur dans le formulaire d'invitation (${formWithErrors.errors.map(_.message).mkString(", ")})."
+            eventService.log(InviteNotCreated, error)
+            Future(
+              Redirect(
+                routes.ApplicationController.show(applicationId).withFragment("answer-error")
+              ).flashing("answer-error" -> error, "opened-tab" -> "invite")
+            )
+          },
+          inviteData => {
+            val currentAreaId = application.area
+            usersWhoCanBeInvitedOn(application).map {
+              usersWhoCanBeInvited =>
+                val invitedUsers: Map[UUID, String] = usersWhoCanBeInvited
+                  .filter(user => inviteData.invitedUsers.contains[UUID](user.id))
+                  .map(user => (user.id, contextualizedUserName(user, currentAreaId)))
+                  .toMap
 
-              val answer = Answer(
-                UUID.randomUUID(),
-                applicationId,
-                Time.nowParis(),
-                inviteData.message,
-                request.currentUser.id,
-                contextualizedUserName(request.currentUser, currentAreaId),
-                invitedUsers,
-                not(inviteData.privateToHelpers),
-                false,
-                Some(Map.empty)
-              )
+                val answer = Answer(
+                  UUID.randomUUID(),
+                  applicationId,
+                  Time.nowParis(),
+                  inviteData.message,
+                  request.currentUser.id,
+                  contextualizedUserName(request.currentUser, currentAreaId),
+                  invitedUsers,
+                  not(inviteData.privateToHelpers),
+                  false,
+                  Some(Map.empty)
+                )
 
-              if (applicationService.add(applicationId, answer) == 1) {
-                notificationsService.newAnswer(application, answer)
-                eventService.log(
-                  AgentsAdded,
-                  s"L'ajout d'utilisateur ${answer.id} a été créé sur la demande $applicationId",
-                  Some(application)
-                )
-                Redirect(routes.ApplicationController.myApplications())
-                  .flashing("success" -> "Les utilisateurs ont été invités sur la demande")
-              } else {
-                eventService.log(
-                  AgentsNotAdded,
-                  s"L'ajout d'utilisateur ${answer.id} n'a pas été créé sur la demande $applicationId : problème BDD",
-                  Some(application)
-                )
-                InternalServerError("Les utilisateurs n'ont pas pu être invités")
-              }
+                if (applicationService.add(applicationId, answer) == 1) {
+                  notificationsService.newAnswer(application, answer)
+                  eventService.log(
+                    AgentsAdded,
+                    s"L'ajout d'utilisateur ${answer.id} a été créé sur la demande $applicationId",
+                    Some(application)
+                  )
+                  Redirect(routes.ApplicationController.myApplications())
+                    .flashing("success" -> "Les utilisateurs ont été invités sur la demande")
+                } else {
+                  eventService.log(
+                    AgentsNotAdded,
+                    s"L'ajout d'utilisateur ${answer.id} n'a pas été créé sur la demande $applicationId : problème BDD",
+                    Some(application)
+                  )
+                  InternalServerError("Les utilisateurs n'ont pas pu être invités")
+                }
+            }
           }
-        }
-      )
+        )
+      }
     }
-  }
 
-  def inviteExpert(applicationId: UUID): Action[AnyContent] = loginAction.async {
-    implicit request =>
+  def inviteExpert(applicationId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
       withApplication(applicationId) { application: Application =>
         val currentAreaId = application.area
         if (application.canHaveExpertsInvitedBy(request.currentUser)) {
@@ -1038,69 +1071,72 @@ case class ApplicationController @Inject() (
           )
         }
       }
-  }
+    }
 
-  def terminate(applicationId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
-    withApplication(applicationId) { application: Application =>
-      request.getQueryString("usefulness") match {
-        case None =>
-          eventService
-            .log(
-              TerminateIncompleted,
-              s"La demande de clôture pour $applicationId est incomplète"
+  def terminate(applicationId: UUID): Action[AnyContent] =
+    loginAction.async { implicit request =>
+      withApplication(applicationId) { application: Application =>
+        request.getQueryString("usefulness") match {
+          case None =>
+            eventService
+              .log(
+                TerminateIncompleted,
+                s"La demande de clôture pour $applicationId est incomplète"
+              )
+            Future(
+              BadGateway(
+                s"L'utilité de la demande n'est pas présente, il s'agit sûrement d'une erreur. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
+              )
             )
-          Future(
-            BadGateway(
-              s"L'utilité de la demande n'est pas présente, il s'agit sûrement d'une erreur. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-            )
-          )
-        case Some(usefulness) =>
-          val finalUsefulness = if (request.currentUser.id == application.creatorUserId) {
-            Some(usefulness)
-          } else {
-            None
-          }
-          if (application.canBeClosedBy(request.currentUser)) {
-            if (applicationService
-                  .close(applicationId, finalUsefulness, Time.nowParis())) {
-              eventService
-                .log(
-                  TerminateCompleted,
-                  s"La demande $applicationId est clôturée",
+          case Some(usefulness) =>
+            val finalUsefulness = if (request.currentUser.id == application.creatorUserId) {
+              Some(usefulness)
+            } else {
+              None
+            }
+            if (application.canBeClosedBy(request.currentUser)) {
+              if (
+                applicationService
+                  .close(applicationId, finalUsefulness, Time.nowParis())
+              ) {
+                eventService
+                  .log(
+                    TerminateCompleted,
+                    s"La demande $applicationId est clôturée",
+                    Some(application)
+                  )
+                val successMessage =
+                  s"""|La demande "${application.subject}" a bien été clôturée. 
+                    |Bravo et merci pour la résolution de cette demande !""".stripMargin
+                Future(
+                  Redirect(routes.ApplicationController.myApplications())
+                    .flashing("success" -> successMessage)
+                )
+              } else {
+                eventService.log(
+                  TerminateError,
+                  s"La demande $applicationId n'a pas pu être clôturée en BDD",
                   Some(application)
                 )
-              val successMessage =
-                s"""|La demande "${application.subject}" a bien été clôturée. 
-                    |Bravo et merci pour la résolution de cette demande !""".stripMargin
-              Future(
-                Redirect(routes.ApplicationController.myApplications())
-                  .flashing("success" -> successMessage)
-              )
+                Future(
+                  InternalServerError(
+                    "Erreur interne: l'application n'a pas pu être indiquée comme clôturée"
+                  )
+                )
+              }
             } else {
               eventService.log(
-                TerminateError,
-                s"La demande $applicationId n'a pas pu être clôturée en BDD",
+                TerminateUnauthorized,
+                s"L'utilisateur n'a pas le droit de clôturer la demande $applicationId",
                 Some(application)
               )
               Future(
-                InternalServerError(
-                  "Erreur interne: l'application n'a pas pu être indiquée comme clôturée"
-                )
+                Unauthorized("Seul le créateur de la demande ou un expert peut clore la demande")
               )
             }
-          } else {
-            eventService.log(
-              TerminateUnauthorized,
-              s"L'utilisateur n'a pas le droit de clôturer la demande $applicationId",
-              Some(application)
-            )
-            Future(
-              Unauthorized("Seul le créateur de la demande ou un expert peut clore la demande")
-            )
-          }
+        }
       }
     }
-  }
 
   //
   // Signature Cookie (for shared accounts)

--- a/app/controllers/AreaController.scala
+++ b/app/controllers/AreaController.scala
@@ -37,40 +37,49 @@ case class AreaController @Inject() (
     .toList
 
   @deprecated("You should not need area", "v0.1")
-  def change(areaId: UUID) = loginAction { implicit request =>
-    if (!request.currentUser.areas.contains[UUID](areaId)) {
-      eventService.log(ChangeAreaUnauthorized, s"Accès à la zone $areaId non autorisé")
-      Unauthorized(
-        s"Vous n'avez pas les droits suffisants pour accèder à cette zone. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-      )
-    } else {
-      eventService.log(AreaChanged, s"Changement vers la zone $areaId")
-      val redirect = request
-        .getQueryString("redirect")
-        .map(url => Redirect(url))
-        .getOrElse(Redirect(routes.ApplicationController.myApplications()))
-      redirect.withSession(request.session - "areaId" + ("areaId" -> areaId.toString))
-    }
-  }
-
-  def all = loginAction.async { implicit request =>
-    if (!request.currentUser.admin && !request.currentUser.groupAdmin) {
-      eventService.log(AllAreaUnauthorized, "Accès non autorisé pour voir la page des territoires")
-      Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
-    } else {
-      val userGroupsFuture: Future[List[UserGroup]] = if (request.currentUser.admin) {
-        userGroupService.byAreas(request.currentUser.areas)
-      } else {
-        Future(userGroupService.byIds(request.currentUser.groupIds))
-      }
-      userGroupsFuture.map { userGroups =>
-        Ok(
-          views.html
-            .allArea(request.currentUser, request.rights)(Area.all, areasWithLoginByKey, userGroups)
+  def change(areaId: UUID) =
+    loginAction { implicit request =>
+      if (!request.currentUser.areas.contains[UUID](areaId)) {
+        eventService.log(ChangeAreaUnauthorized, s"Accès à la zone $areaId non autorisé")
+        Unauthorized(
+          s"Vous n'avez pas les droits suffisants pour accèder à cette zone. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
         )
+      } else {
+        eventService.log(AreaChanged, s"Changement vers la zone $areaId")
+        val redirect = request
+          .getQueryString("redirect")
+          .map(url => Redirect(url))
+          .getOrElse(Redirect(routes.ApplicationController.myApplications()))
+        redirect.withSession(request.session - "areaId" + ("areaId" -> areaId.toString))
       }
     }
-  }
+
+  def all =
+    loginAction.async { implicit request =>
+      if (!request.currentUser.admin && !request.currentUser.groupAdmin) {
+        eventService.log(
+          AllAreaUnauthorized,
+          "Accès non autorisé pour voir la page des territoires"
+        )
+        Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
+      } else {
+        val userGroupsFuture: Future[List[UserGroup]] = if (request.currentUser.admin) {
+          userGroupService.byAreas(request.currentUser.areas)
+        } else {
+          Future(userGroupService.byIds(request.currentUser.groupIds))
+        }
+        userGroupsFuture.map { userGroups =>
+          Ok(
+            views.html
+              .allArea(request.currentUser, request.rights)(
+                Area.all,
+                areasWithLoginByKey,
+                userGroups
+              )
+          )
+        }
+      }
+    }
 
   private val organisationGroupingAll: List[Set[Organisation]] = (
     List(
@@ -117,66 +126,68 @@ case class AreaController @Inject() (
       ).map(Set(_))
   ).map(_.flatMap(id => Organisation.byId(Organisation.Id(id))))
 
-  def deploymentDashboard = loginAction.async { implicit request =>
-    asUserWithAuthorization(Authorization.isAdminOrObserver) { () =>
-      DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
-    } { () =>
-      val userGroups = userGroupService.allGroups
-      userService.all.map { users =>
-        def usersIn(area: Area, organisationSet: Set[Organisation]): List[User] =
-          for {
-            group <- userGroups.filter(group =>
-              group.areaIds.contains[UUID](area.id)
-                && organisationSet.exists(group.organisationSetOrDeducted.contains[Organisation])
-            )
-            user <- users if user.groupIds.contains[UUID](group.id)
-          } yield user
+  def deploymentDashboard =
+    loginAction.async { implicit request =>
+      asUserWithAuthorization(Authorization.isAdminOrObserver) { () =>
+        DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
+      } { () =>
+        val userGroups = userGroupService.allGroups
+        userService.all.map { users =>
+          def usersIn(area: Area, organisationSet: Set[Organisation]): List[User] =
+            for {
+              group <- userGroups.filter(group =>
+                group.areaIds.contains[UUID](area.id)
+                  && organisationSet.exists(group.organisationSetOrDeducted.contains[Organisation])
+              )
+              user <- users if user.groupIds.contains[UUID](group.id)
+            } yield user
 
-        val organisationGrouping =
-          if (request.getQueryString("uniquement-fs").getOrElse("oui") == "oui") {
-            organisationGroupingFranceService
-          } else {
-            organisationGroupingAll
+          val organisationGrouping =
+            if (request.getQueryString("uniquement-fs").getOrElse("oui") == "oui") {
+              organisationGroupingFranceService
+            } else {
+              organisationGroupingAll
+            }
+
+          val data = for {
+            area <- request.currentUser.areas.flatMap(Area.fromId).filterNot(_.name == "Demo")
+          } yield {
+            val organisationMap: List[(Set[Organisation], Int)] = for {
+              organisations <- organisationGrouping
+              users = usersIn(area, organisations)
+              userSum = users.count(_.instructor)
+            } yield organisations -> userSum
+            (area, organisationMap, organisationMap.count(_._2 > 0))
           }
 
-        val data = for {
-          area <- request.currentUser.areas.flatMap(Area.fromId).filterNot(_.name == "Demo")
-        } yield {
-          val organisationMap: List[(Set[Organisation], Int)] = for {
-            organisations <- organisationGrouping
-            users = usersIn(area, organisations)
-            userSum = users.count(_.instructor)
-          } yield organisations -> userSum
-          (area, organisationMap, organisationMap.count(_._2 > 0))
-        }
+          val organisationSetToCountOfCounts: Map[Set[Organisation], Int] = {
+            val organisationSetToCount: List[(Set[Organisation], Int)] = data.flatMap(_._2)
+            val countsGroupedByOrganisationSet
+                : Map[Set[Organisation], List[(Set[Organisation], Int)]] =
+              organisationSetToCount.groupBy(_._1)
+            val organisationSetToCountOfCounts: Map[Set[Organisation], Int] =
+              countsGroupedByOrganisationSet.view.mapValues(_.map(_._2).count(_ > 0)).toMap
+            organisationSetToCountOfCounts
+          }
 
-        val organisationSetToCountOfCounts: Map[Set[Organisation], Int] = {
-          val organisationSetToCount: List[(Set[Organisation], Int)] = data.flatMap(_._2)
-          val countsGroupedByOrganisationSet
-              : Map[Set[Organisation], List[(Set[Organisation], Int)]] =
-            organisationSetToCount.groupBy(_._1)
-          val organisationSetToCountOfCounts: Map[Set[Organisation], Int] =
-            countsGroupedByOrganisationSet.view.mapValues(_.map(_._2).count(_ > 0)).toMap
-          organisationSetToCountOfCounts
-        }
-
-        Ok(
-          views.html.deploymentDashboard(request.currentUser, request.rights)(
-            data,
-            organisationSetToCountOfCounts,
-            organisationGrouping
+          Ok(
+            views.html.deploymentDashboard(request.currentUser, request.rights)(
+              data,
+              organisationSetToCountOfCounts,
+              organisationGrouping
+            )
           )
-        )
+        }
       }
     }
-  }
 
-  def franceServiceDeploymentDashboard = loginAction.async { implicit request =>
-    asUserWithAuthorization(Authorization.isAdminOrObserver) { () =>
-      DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
-    } { () =>
-      Future(Ok(views.html.franceServiceDeploymentDashboard(request.currentUser, request.rights)))
+  def franceServiceDeploymentDashboard =
+    loginAction.async { implicit request =>
+      asUserWithAuthorization(Authorization.isAdminOrObserver) { () =>
+        DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
+      } { () =>
+        Future(Ok(views.html.franceServiceDeploymentDashboard(request.currentUser, request.rights)))
+      }
     }
-  }
 
 }

--- a/app/controllers/GroupController.scala
+++ b/app/controllers/GroupController.scala
@@ -44,135 +44,142 @@ case class GroupController @Inject() (
     with GroupOperators
     with UserOperators {
 
-  def deleteUnusedGroupById(groupId: UUID): Action[AnyContent] = loginAction { implicit request =>
-    withGroup(groupId) { group: UserGroup =>
-      asAdminOfGroupZone(group) { () =>
-        GroupDeletionUnauthorized -> s"Droits insuffisants pour la suppression du groupe ${groupId}."
-      } { () =>
-        val empty = groupService.isGroupEmpty(group.id)
-        if (not(empty)) {
-          eventService.log(
-            UserGroupDeletionUnauthorized,
-            description = "Tentative de suppression d'un groupe utilisé."
-          )
-          Unauthorized("Group is not unused.")
-        } else {
-          groupService.deleteById(groupId)
-          eventService.log(UserGroupDeleted, s"Suppression du groupe ${groupId}.")
-          Redirect(
-            routes.UserController.all(group.areaIds.headOption.getOrElse(Area.allArea.id)),
-            303
-          )
-        }
-      }
-    }
-  }
-
-  def editGroup(id: UUID): Action[AnyContent] = loginAction { implicit request =>
-    withGroup(id) { group: UserGroup =>
-      if (!group.canHaveUsersAddedBy(request.currentUser)) {
-        eventService.log(EditGroupUnauthorized, s"Accès non autorisé à l'edition de ce groupe")
-        Unauthorized("Vous ne pouvez pas éditer ce groupe : êtes-vous dans la bonne zone ?")
-      } else {
-        val groupUsers = userService.byGroupIds(List(id))
-        eventService.log(EditGroupShowed, s"Visualise la vue de modification du groupe")
-        val isEmpty = groupService.isGroupEmpty(group.id)
-        Ok(
-          views.html.editGroup(request.currentUser, request.rights)(
-            group,
-            groupUsers,
-            isEmpty
-          )
-        )
-      }
-    }
-  }
-
-  def addGroup(): Action[AnyContent] = loginAction { implicit request =>
-    asAdmin(() => AddGroupUnauthorized -> s"Accès non autorisé pour ajouter un groupe") { () =>
-      addGroupForm(Time.timeZoneParis).bindFromRequest.fold(
-        formWithErrors => {
-          eventService
-            .log(AddUserGroupError, s"Essai d'ajout d'un groupe avec des erreurs de validation")
-          Redirect(routes.UserController.home).flashing(
-            "error" -> s"Impossible d'ajouter le groupe : ${formWithErrors.errors.mkString}"
-          )
-        },
-        group =>
-          groupService
-            .add(group)
-            .fold(
-              { error: String =>
-                eventService.log(AddUserGroupError, s"Impossible d'ajouter le groupe dans la BDD")
-                Redirect(routes.UserController.home)
-                  .flashing("error" -> s"Impossible d'ajouter le groupe : $error")
-              }, { Unit =>
-                eventService.log(
-                  UserGroupCreated,
-                  s"Groupe ${group.name} (id : ${group.id}) ajouté par l'utilisateur d'id ${request.currentUser.id}"
-                )
-                Redirect(routes.GroupController.editGroup(group.id))
-                  .flashing("success" -> "Groupe ajouté")
-              }
+  def deleteUnusedGroupById(groupId: UUID): Action[AnyContent] =
+    loginAction { implicit request =>
+      withGroup(groupId) { group: UserGroup =>
+        asAdminOfGroupZone(group) { () =>
+          GroupDeletionUnauthorized -> s"Droits insuffisants pour la suppression du groupe ${groupId}."
+        } { () =>
+          val empty = groupService.isGroupEmpty(group.id)
+          if (not(empty)) {
+            eventService.log(
+              UserGroupDeletionUnauthorized,
+              description = "Tentative de suppression d'un groupe utilisé."
             )
-      )
+            Unauthorized("Group is not unused.")
+          } else {
+            groupService.deleteById(groupId)
+            eventService.log(UserGroupDeleted, s"Suppression du groupe ${groupId}.")
+            Redirect(
+              routes.UserController.all(group.areaIds.headOption.getOrElse(Area.allArea.id)),
+              303
+            )
+          }
+        }
+      }
     }
-  }
 
-  def editGroupPost(groupId: UUID): Action[AnyContent] = loginAction { implicit request =>
-    asAdmin(() => EditGroupUnauthorized -> s"Accès non autorisé à l'edition de ce groupe") { () =>
-      withGroup(groupId) { currentGroup: UserGroup =>
-        if (not(currentGroup.canHaveUsersAddedBy(request.currentUser))) {
-          eventService.log(
-            AddUserToGroupUnauthorized,
-            s"L'utilisateur ${request.currentUser.id} n'est pas authorisé à ajouter des utilisateurs au groupe ${currentGroup.id}."
-          )
-          Unauthorized("Vous n'êtes pas authorisé à ajouter des utilisateurs à ce groupe.")
+  def editGroup(id: UUID): Action[AnyContent] =
+    loginAction { implicit request =>
+      withGroup(id) { group: UserGroup =>
+        if (!group.canHaveUsersAddedBy(request.currentUser)) {
+          eventService.log(EditGroupUnauthorized, s"Accès non autorisé à l'edition de ce groupe")
+          Unauthorized("Vous ne pouvez pas éditer ce groupe : êtes-vous dans la bonne zone ?")
         } else {
-          addGroupForm(Time.timeZoneParis).bindFromRequest.fold(
-            formWithError => {
-              eventService.log(
-                EditUserGroupError,
-                s"Essai d'edition d'un groupe avec des erreurs de validation"
-              )
-              Redirect(routes.GroupController.editGroup(groupId)).flashing(
-                "error" -> s"Impossible de modifier le groupe (erreur de formulaire) : ${formWithError.errors.mkString}"
-              )
-            },
-            group =>
-              if (groupService.edit(group.copy(id = groupId))) {
-                eventService.log(UserGroupEdited, s"Groupe édité")
-                Redirect(routes.GroupController.editGroup(groupId))
-                  .flashing("success" -> "Groupe modifié")
-              } else {
-                eventService
-                  .log(EditUserGroupError, s"Impossible de modifier le groupe dans la BDD")
-                Redirect(routes.GroupController.editGroup(groupId))
-                  .flashing(
-                    "error" -> "Impossible de modifier le groupe: erreur en base de donnée"
-                  )
-              }
+          val groupUsers = userService.byGroupIds(List(id))
+          eventService.log(EditGroupShowed, s"Visualise la vue de modification du groupe")
+          val isEmpty = groupService.isGroupEmpty(group.id)
+          Ok(
+            views.html.editGroup(request.currentUser, request.rights)(
+              group,
+              groupUsers,
+              isEmpty
+            )
           )
         }
       }
     }
-  }
 
-  def addGroupForm[A](timeZone: ZoneId)(implicit request: RequestWithUserData[A]) = Form(
-    mapping(
-      "id" -> ignored(UUID.randomUUID()),
-      "name" -> text(maxLength = 60),
-      "description" -> optional(text),
-      "insee-code" -> list(text),
-      "creationDate" -> ignored(ZonedDateTime.now(timeZone)),
-      "area-ids" -> list(uuid)
-        .verifying(
-          "Vous devez sélectionner les territoires sur lequel vous êtes admin",
-          areaIds => areaIds.forall(request.currentUser.areas.contains[UUID])
+  def addGroup(): Action[AnyContent] =
+    loginAction { implicit request =>
+      asAdmin(() => AddGroupUnauthorized -> s"Accès non autorisé pour ajouter un groupe") { () =>
+        addGroupForm(Time.timeZoneParis).bindFromRequest.fold(
+          formWithErrors => {
+            eventService
+              .log(AddUserGroupError, s"Essai d'ajout d'un groupe avec des erreurs de validation")
+            Redirect(routes.UserController.home).flashing(
+              "error" -> s"Impossible d'ajouter le groupe : ${formWithErrors.errors.mkString}"
+            )
+          },
+          group =>
+            groupService
+              .add(group)
+              .fold(
+                { error: String =>
+                  eventService.log(AddUserGroupError, s"Impossible d'ajouter le groupe dans la BDD")
+                  Redirect(routes.UserController.home)
+                    .flashing("error" -> s"Impossible d'ajouter le groupe : $error")
+                },
+                { Unit =>
+                  eventService.log(
+                    UserGroupCreated,
+                    s"Groupe ${group.name} (id : ${group.id}) ajouté par l'utilisateur d'id ${request.currentUser.id}"
+                  )
+                  Redirect(routes.GroupController.editGroup(group.id))
+                    .flashing("success" -> "Groupe ajouté")
+                }
+              )
         )
-        .verifying("Vous devez sélectionner au moins 1 territoire", _.nonEmpty),
-      "organisation" -> optional(of[Organisation.Id]),
-      "email" -> optional(email)
-    )(UserGroup.apply)(UserGroup.unapply)
-  )
+      }
+    }
+
+  def editGroupPost(groupId: UUID): Action[AnyContent] =
+    loginAction { implicit request =>
+      asAdmin(() => EditGroupUnauthorized -> s"Accès non autorisé à l'edition de ce groupe") { () =>
+        withGroup(groupId) { currentGroup: UserGroup =>
+          if (not(currentGroup.canHaveUsersAddedBy(request.currentUser))) {
+            eventService.log(
+              AddUserToGroupUnauthorized,
+              s"L'utilisateur ${request.currentUser.id} n'est pas authorisé à ajouter des utilisateurs au groupe ${currentGroup.id}."
+            )
+            Unauthorized("Vous n'êtes pas authorisé à ajouter des utilisateurs à ce groupe.")
+          } else {
+            addGroupForm(Time.timeZoneParis).bindFromRequest.fold(
+              formWithError => {
+                eventService.log(
+                  EditUserGroupError,
+                  s"Essai d'edition d'un groupe avec des erreurs de validation"
+                )
+                Redirect(routes.GroupController.editGroup(groupId)).flashing(
+                  "error" -> s"Impossible de modifier le groupe (erreur de formulaire) : ${formWithError.errors.mkString}"
+                )
+              },
+              group =>
+                if (groupService.edit(group.copy(id = groupId))) {
+                  eventService.log(UserGroupEdited, s"Groupe édité")
+                  Redirect(routes.GroupController.editGroup(groupId))
+                    .flashing("success" -> "Groupe modifié")
+                } else {
+                  eventService
+                    .log(EditUserGroupError, s"Impossible de modifier le groupe dans la BDD")
+                  Redirect(routes.GroupController.editGroup(groupId))
+                    .flashing(
+                      "error" -> "Impossible de modifier le groupe: erreur en base de donnée"
+                    )
+                }
+            )
+          }
+        }
+      }
+    }
+
+  def addGroupForm[A](timeZone: ZoneId)(implicit request: RequestWithUserData[A]) =
+    Form(
+      mapping(
+        "id" -> ignored(UUID.randomUUID()),
+        "name" -> text(maxLength = 60),
+        "description" -> optional(text),
+        "insee-code" -> list(text),
+        "creationDate" -> ignored(ZonedDateTime.now(timeZone)),
+        "area-ids" -> list(uuid)
+          .verifying(
+            "Vous devez sélectionner les territoires sur lequel vous êtes admin",
+            areaIds => areaIds.forall(request.currentUser.areas.contains[UUID])
+          )
+          .verifying("Vous devez sélectionner au moins 1 territoire", _.nonEmpty),
+        "organisation" -> optional(of[Organisation.Id]),
+        "email" -> optional(email)
+      )(UserGroup.apply)(UserGroup.unapply)
+    )
+
 }

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -13,56 +13,62 @@ import views.home.LoginPanel
   * application's home page.
   */
 @Singleton
-class HomeController @Inject() (loginAction: LoginAction, db: Database)(
-    implicit webJarsUtil: WebJarsUtil
+class HomeController @Inject() (loginAction: LoginAction, db: Database)(implicit
+    webJarsUtil: WebJarsUtil
 ) extends InjectedController
     with play.api.i18n.I18nSupport {
 
   private val log = Logger(classOf[HomeController])
 
-  def index: Action[AnyContent] = Action { implicit request =>
-    val needsRedirect = request.session
-      .get("userId")
-      .orElse(request.queryString.get("token"))
-      .orElse(request.queryString.get("key"))
-      .isDefined
-    if (needsRedirect)
-      TemporaryRedirect(
-        s"${routes.ApplicationController.myApplications()}?${request.rawQueryString}"
-      )
-    else
-      request.flash.get("email") match {
-        case None =>
-          Ok(views.html.home.page(LoginPanel.ConnectionForm))
-        case Some(email) =>
-          Ok(views.html.home.page(LoginPanel.SendbackEmailForm(email, request.flash.get("error"))))
-      }
-  }
-
-  def status: Action[AnyContent] = Action {
-    val connectionValid =
-      try {
-        db.withConnection {
-          _.isValid(1)
+  def index: Action[AnyContent] =
+    Action { implicit request =>
+      val needsRedirect = request.session
+        .get("userId")
+        .orElse(request.queryString.get("token"))
+        .orElse(request.queryString.get("key"))
+        .isDefined
+      if (needsRedirect)
+        TemporaryRedirect(
+          s"${routes.ApplicationController.myApplications()}?${request.rawQueryString}"
+        )
+      else
+        request.flash.get("email") match {
+          case None =>
+            Ok(views.html.home.page(LoginPanel.ConnectionForm))
+          case Some(email) =>
+            Ok(
+              views.html.home.page(LoginPanel.SendbackEmailForm(email, request.flash.get("error")))
+            )
         }
-      } catch {
-        case throwable: Throwable =>
-          log.error("Database check error", throwable)
-          false
-      }
-    if (connectionValid) {
-      Ok("OK")
-    } else {
-      ServiceUnavailable("Indisponible")
     }
-  }
 
-  def help: Action[AnyContent] = loginAction { implicit request =>
-    Ok(views.html.help(request.currentUser, request.rights))
-  }
+  def status: Action[AnyContent] =
+    Action {
+      val connectionValid =
+        try {
+          db.withConnection {
+            _.isValid(1)
+          }
+        } catch {
+          case throwable: Throwable =>
+            log.error("Database check error", throwable)
+            false
+        }
+      if (connectionValid) {
+        Ok("OK")
+      } else {
+        ServiceUnavailable("Indisponible")
+      }
+    }
 
-  def welcome: Action[AnyContent] = loginAction { implicit request =>
-    Ok(views.html.welcome(request.currentUser, request.rights))
-  }
+  def help: Action[AnyContent] =
+    loginAction { implicit request =>
+      Ok(views.html.help(request.currentUser, request.rights))
+    }
+
+  def welcome: Action[AnyContent] =
+    loginAction { implicit request =>
+      Ok(views.html.welcome(request.currentUser, request.rights))
+    }
 
 }

--- a/app/controllers/JavascriptController.scala
+++ b/app/controllers/JavascriptController.scala
@@ -8,15 +8,17 @@ import play.api.routing.JavaScriptReverseRouter
 @Singleton
 class JavascriptController() extends InjectedController {
 
-  def javascriptRoutes = Action { implicit request =>
-    Ok(
-      JavaScriptReverseRouter("jsRoutes")(
-        routes.javascript.ApiController.franceServiceDeployment,
-        routes.javascript.GroupController.deleteUnusedGroupById,
-        routes.javascript.ApplicationController.all,
-        routes.javascript.UserController.all,
-        routes.javascript.UserController.editUser
-      )
-    ).as(MimeTypes.JAVASCRIPT)
-  }
+  def javascriptRoutes =
+    Action { implicit request =>
+      Ok(
+        JavaScriptReverseRouter("jsRoutes")(
+          routes.javascript.ApiController.franceServiceDeployment,
+          routes.javascript.GroupController.deleteUnusedGroupById,
+          routes.javascript.ApplicationController.all,
+          routes.javascript.UserController.all,
+          routes.javascript.UserController.editUser
+        )
+      ).as(MimeTypes.JAVASCRIPT)
+    }
+
 }

--- a/app/controllers/LoginController.scala
+++ b/app/controllers/LoginController.scala
@@ -27,90 +27,94 @@ class LoginController @Inject() (
     * when the email is in the query "?email=xxx", we do not check the CSRF token
     * because the API is used externally.
     */
-  def login: Action[AnyContent] = Action.async { implicit request =>
-    val emailFromRequestOrQueryParamOrFlash: Option[String] = request.body.asFormUrlEncoded
-      .flatMap(_.get("email").flatMap(_.headOption))
-      .orElse(request.getQueryString("email"))
-      .orElse(request.flash.get("email"))
-    emailFromRequestOrQueryParamOrFlash.fold {
-      Future(Ok(views.html.home.page(LoginPanel.ConnectionForm)))
-    } { email =>
-      userService
-        .byEmail(email)
-        .fold {
-          // TODO: this should be removed
-          val user = User.systemUser
-          LoginAction.readUserRights(user).map { userRights =>
-            implicit val requestWithUserData =
-              new RequestWithUserData(user, userRights, request)
-            eventService.log(UnknownEmail, s"Aucun compte actif à cette adresse mail $email")
-            val message =
-              """Aucun compte actif n'est associé à cette adresse e-mail.
+  def login: Action[AnyContent] =
+    Action.async { implicit request =>
+      val emailFromRequestOrQueryParamOrFlash: Option[String] = request.body.asFormUrlEncoded
+        .flatMap(_.get("email").flatMap(_.headOption))
+        .orElse(request.getQueryString("email"))
+        .orElse(request.flash.get("email"))
+      emailFromRequestOrQueryParamOrFlash.fold {
+        Future(Ok(views.html.home.page(LoginPanel.ConnectionForm)))
+      } { email =>
+        userService
+          .byEmail(email)
+          .fold {
+            // TODO: this should be removed
+            val user = User.systemUser
+            LoginAction.readUserRights(user).map { userRights =>
+              implicit val requestWithUserData =
+                new RequestWithUserData(user, userRights, request)
+              eventService.log(UnknownEmail, s"Aucun compte actif à cette adresse mail $email")
+              val message =
+                """Aucun compte actif n'est associé à cette adresse e-mail.
                 |Merci de vérifier qu'il s'agit bien de votre adresse professionnelle et nominative qui doit être sous la forme : prenom.nom@votre-structure.fr""".stripMargin
-            Redirect(routes.LoginController.login)
-              .flashing("error" -> message, "email-value" -> email)
-          }
-        } { user: User =>
-          LoginAction.readUserRights(user).map { userRights =>
-            val loginToken =
-              LoginToken.forUserId(user.id, tokenExpirationInMinutes, request.remoteAddress)
-            tokenService.create(loginToken)
-            // Here we want to redirect some users to more useful pages:
-            // observer => /stats
-            val path: String = {
-              val tmpPath = request.flash.get("path").getOrElse(routes.HomeController.index.url)
-              val shouldChangeObserverPath: Boolean =
-                Authorization.isObserver(userRights) &&
-                  user.cguAcceptationDate.nonEmpty &&
-                  ((tmpPath: String) == (routes.HomeController.index.url: String))
-              if (shouldChangeObserverPath) {
-                routes.ApplicationController.stats.url
-              } else {
-                tmpPath
-              }
+              Redirect(routes.LoginController.login)
+                .flashing("error" -> message, "email-value" -> email)
             }
-            val url = routes.LoginController.magicLinkAntiConsumptionPage.absoluteURL()
-            notificationService.newLoginRequest(url, path, user, loginToken)
+          } { user: User =>
+            LoginAction.readUserRights(user).map { userRights =>
+              val loginToken =
+                LoginToken.forUserId(user.id, tokenExpirationInMinutes, request.remoteAddress)
+              tokenService.create(loginToken)
+              // Here we want to redirect some users to more useful pages:
+              // observer => /stats
+              val path: String = {
+                val tmpPath = request.flash.get("path").getOrElse(routes.HomeController.index.url)
+                val shouldChangeObserverPath: Boolean =
+                  Authorization.isObserver(userRights) &&
+                    user.cguAcceptationDate.nonEmpty &&
+                    ((tmpPath: String) == (routes.HomeController.index.url: String))
+                if (shouldChangeObserverPath) {
+                  routes.ApplicationController.stats.url
+                } else {
+                  tmpPath
+                }
+              }
+              val url = routes.LoginController.magicLinkAntiConsumptionPage.absoluteURL()
+              notificationService.newLoginRequest(url, path, user, loginToken)
 
-            implicit val requestWithUserData =
-              new RequestWithUserData(user, userRights, request)
-            val emailInBody = request.body.asFormUrlEncoded.flatMap(_.get("email")).nonEmpty
-            val emailInFlash = request.flash.get("email").nonEmpty
-            eventService.log(
-              GenerateToken,
-              s"Génère un token pour une connexion par email body=${emailInBody}&flash=${emailInFlash}"
-            )
+              implicit val requestWithUserData =
+                new RequestWithUserData(user, userRights, request)
+              val emailInBody = request.body.asFormUrlEncoded.flatMap(_.get("email")).nonEmpty
+              val emailInFlash = request.flash.get("email").nonEmpty
+              eventService.log(
+                GenerateToken,
+                s"Génère un token pour une connexion par email body=${emailInBody}&flash=${emailInFlash}"
+              )
 
-            val successMessage = request
-              .getQueryString("action")
-              .flatMap(actionName =>
-                if (actionName == "sendemailback")
-                  Some("Un nouveau lien de connexion vient de vous être envoyé par e-mail.")
-                else
-                  None
+              val successMessage = request
+                .getQueryString("action")
+                .flatMap(actionName =>
+                  if (actionName == "sendemailback")
+                    Some("Un nouveau lien de connexion vient de vous être envoyé par e-mail.")
+                  else
+                    None
+                )
+              Ok(
+                views.html.home.page(
+                  LoginPanel.EmailSentFeedback(user, tokenExpirationInMinutes, successMessage)
+                )
               )
-            Ok(
-              views.html.home.page(
-                LoginPanel.EmailSentFeedback(user, tokenExpirationInMinutes, successMessage)
-              )
-            )
+            }
           }
-        }
+      }
     }
-  }
 
-  def magicLinkAntiConsumptionPage: Action[AnyContent] = Action { implicit request =>
-    (request.getQueryString("token"), request.getQueryString("path")) match {
-      case (Some(token), Some(path)) =>
-        Ok(views.html.loginHome(Right((token, path)), tokenExpirationInMinutes))
-      case _ =>
-        TemporaryRedirect(routes.LoginController.login.url).flashing(
-          "error" -> "Il y a une erreur dans votre lien de connexion. Merci de contacter l'équipe Administration+"
-        )
+  def magicLinkAntiConsumptionPage: Action[AnyContent] =
+    Action { implicit request =>
+      (request.getQueryString("token"), request.getQueryString("path")) match {
+        case (Some(token), Some(path)) =>
+          Ok(views.html.loginHome(Right((token, path)), tokenExpirationInMinutes))
+        case _ =>
+          TemporaryRedirect(routes.LoginController.login.url).flashing(
+            "error" -> "Il y a une erreur dans votre lien de connexion. Merci de contacter l'équipe Administration+"
+          )
+      }
     }
-  }
 
-  def disconnect: Action[AnyContent] = Action {
-    Redirect(routes.LoginController.login).withNewSession
-  }
+  def disconnect: Action[AnyContent] =
+    Action {
+      Redirect(routes.LoginController.login).withNewSession
+    }
+
 }

--- a/app/controllers/Operators.scala
+++ b/app/controllers/Operators.scala
@@ -49,6 +49,7 @@ object Operators {
           Unauthorized("Vous n'êtes pas en charge de la zone de ce groupe.")
         }
       }
+
   }
 
   trait UserOperators {
@@ -107,10 +108,12 @@ object Operators {
         payload: () => Future[Result]
     )(implicit request: RequestWithUserData[AnyContent], ec: ExecutionContext): Future[Result] =
       // TODO: use only Authorization
-      if (not(
-            request.currentUser.canSeeUsersInArea(areaId) ||
-              Authorization.isObserver(request.rights)
-          )) {
+      if (
+        not(
+          request.currentUser.canSeeUsersInArea(areaId) ||
+            Authorization.isObserver(request.rights)
+        )
+      ) {
         val (eventType, description) = event()
         eventService.log(eventType, description = description)
         Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
@@ -136,14 +139,15 @@ object Operators {
           payload()
         }
       }
+
   }
 
   trait ApplicationOperators {
     def applicationService: ApplicationService
     def eventService: EventService
 
-    private def manageApplicationError[A](applicationId: UUID, error: Error)(
-        implicit request: RequestWithUserData[A],
+    private def manageApplicationError[A](applicationId: UUID, error: Error)(implicit
+        request: RequestWithUserData[A],
         ec: ExecutionContext
     ): Future[Result] =
       error match {
@@ -177,10 +181,14 @@ object Operators {
           rights = request.rights
         )
         .flatMap(
-          _.fold(error => manageApplicationError(applicationId, error), {
-            application: Application => payload(application)
-          })
+          _.fold(
+            error => manageApplicationError(applicationId, error),
+            { application: Application =>
+              payload(application)
+            }
+          )
         )
+
   }
 
 }

--- a/app/forms/MapMapping.scala
+++ b/app/forms/MapMapping.scala
@@ -27,6 +27,7 @@ object MapMapping {
     val KeyPattern = ("^" + java.util.regex.Pattern.quote(key) + """\[([ \p{L}0-9_-]+)\].*$""").r
     data.toSeq.collect { case (KeyPattern(index), _) => index }.sorted.distinct
   }
+
 }
 
 /**

--- a/app/helper/CSVUtil.scala
+++ b/app/helper/CSVUtil.scala
@@ -4,4 +4,5 @@ object CSVUtil {
 
   def escape(content: String): String =
     "\"" + content.filterNot(_ == '\n').replace("\"", "\"\"") + "\""
+
 }

--- a/app/helper/Hash.scala
+++ b/app/helper/Hash.scala
@@ -6,4 +6,5 @@ object Hash {
 
   def sha256(string: String) =
     MessageDigest.getInstance("SHA-256").digest(string.getBytes).map("%02x".format(_)).mkString
+
 }

--- a/app/helper/MDLForms.scala
+++ b/app/helper/MDLForms.scala
@@ -18,6 +18,7 @@ object MDLForms {
       val indexes = defaults.filter(!includeIndexes.contains(_)) ++ includeIndexes
       indexes.map(i => fieldRenderer(field("[" + i + "]"), i))
     }
+
   }
 
 }

--- a/app/helper/Math.scala
+++ b/app/helper/Math.scala
@@ -8,4 +8,5 @@ object Math {
     val (lower, upper) = s.sortWith(_ < _).splitAt(s.size / 2)
     if (s.size % 2 == 0) (lower.last + upper.head) / fromInt(2) else upper.head
   }
+
 }

--- a/app/helper/PlayFormHelper.scala
+++ b/app/helper/PlayFormHelper.scala
@@ -9,4 +9,5 @@ object PlayFormHelper {
     val prettyMessages = formError.messages.flatMap(_.split("\\.").lastOption).mkString(", ")
     s"($prettyKey : $prettyMessages)"
   }
+
 }

--- a/app/helper/StringHelper.scala
+++ b/app/helper/StringHelper.scala
@@ -14,6 +14,7 @@ object StringHelper {
 
     def stripSpecialChars: String =
       StringUtils.stripAccents(string.toLowerCase().replaceAll("[-'’ +]", ""))
+
   }
 
   def camelToUnderscoresUpperCase(name: String) =
@@ -22,4 +23,5 @@ object StringHelper {
       .map(_.group(0).toLowerCase)
       .mkString("_")
       .toUpperCase()
+
 }

--- a/app/helper/UUIDHelper.scala
+++ b/app/helper/UUIDHelper.scala
@@ -6,4 +6,5 @@ object UUIDHelper {
 
   def fromString(string: String) =
     scala.util.control.Exception.allCatch.opt(java.util.UUID.fromString(string))
+
 }

--- a/app/models/AgeModel.scala
+++ b/app/models/AgeModel.scala
@@ -29,4 +29,5 @@ trait AgeModel {
     } else {
       s"quelques secondes"
     }
+
 }

--- a/app/models/Answer.scala
+++ b/app/models/Answer.scala
@@ -22,4 +22,5 @@ case class Answer(
   } else {
     Some(7 - ageInDays)
   }
+
 }

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -62,33 +62,37 @@ case class Application(
       answersStripped)
   }
 
-  def longStatus(user: User) = closed match {
-    case true                                                                        => "Clôturée"
-    case _ if user.id == creatorUserId && answers.exists(_.creatorUserID != user.id) => "Répondu"
-    case _
-        if user.id == creatorUserId && seenByUserIds.intersect(invitedUsers.keys.toList).nonEmpty =>
-      "Consultée"
-    case _ if user.id == creatorUserId                   => "Envoyée"
-    case _ if answers.exists(_.creatorUserID == user.id) => "Répondu"
-    case _ if answers.exists(_.creatorUserName.contains(user.qualite)) => {
-      val username = answers
-        .find(_.creatorUserName.contains(user.qualite))
-        .map(_.creatorUserName)
-        .getOrElse("un collègue")
-        .replaceAll("\\(.*\\)", "")
-        .trim
-      s"Répondu par ${username}"
+  def longStatus(user: User) =
+    closed match {
+      case true                                                                        => "Clôturée"
+      case _ if user.id == creatorUserId && answers.exists(_.creatorUserID != user.id) => "Répondu"
+      case _
+          if user.id == creatorUserId && seenByUserIds
+            .intersect(invitedUsers.keys.toList)
+            .nonEmpty =>
+        "Consultée"
+      case _ if user.id == creatorUserId                   => "Envoyée"
+      case _ if answers.exists(_.creatorUserID == user.id) => "Répondu"
+      case _ if answers.exists(_.creatorUserName.contains(user.qualite)) => {
+        val username = answers
+          .find(_.creatorUserName.contains(user.qualite))
+          .map(_.creatorUserName)
+          .getOrElse("un collègue")
+          .replaceAll("\\(.*\\)", "")
+          .trim
+        s"Répondu par ${username}"
+      }
+      case _ if seenByUserIds.contains(user.id) => "Consultée"
+      case _                                    => "Nouvelle"
     }
-    case _ if seenByUserIds.contains(user.id) => "Consultée"
-    case _                                    => "Nouvelle"
-  }
 
-  def status = closed match {
-    case true                                                              => "Clôturée"
-    case _ if answers.filterNot(_.creatorUserID != creatorUserId).nonEmpty => "Répondu"
-    case _ if seenByUserIds.intersect(invitedUsers.keys.toList).nonEmpty   => "Consultée"
-    case _                                                                 => "Nouvelle"
-  }
+  def status =
+    closed match {
+      case true                                                              => "Clôturée"
+      case _ if answers.filterNot(_.creatorUserID != creatorUserId).nonEmpty => "Répondu"
+      case _ if seenByUserIds.intersect(invitedUsers.keys.toList).nonEmpty   => "Consultée"
+      case _                                                                 => "Nouvelle"
+    }
 
   def invitedUsers(users: List[User]): List[User] =
     invitedUsers.keys.flatMap(userId => users.find(_.id == userId)).toList
@@ -176,6 +180,7 @@ case class Application(
   lazy val firstAnswerTimeInMinutes: Option[Int] = firstAgentAnswerDate.map { firstAnswerDate =>
     MINUTES.between(creationDate, firstAnswerDate).toInt
   }
+
 }
 
 object Application {

--- a/app/models/Area.scala
+++ b/app/models/Area.scala
@@ -132,6 +132,7 @@ object Area {
     Area("Yvelines", "Yvelines", "78"),
     Area("exemple", "Demo", "-1")
   )
+
   val allArea = Area(UUIDHelper.namedFrom("all"), "tous les territoires", "0")
 
   val notApplicable = Area("notApplicable", "NotApplicable", "-1")

--- a/app/models/Authorization.scala
+++ b/app/models/Authorization.scala
@@ -153,29 +153,32 @@ object Authorization {
       case _                       => false
     }
 
-  def canSeeApplication(application: Application): Check = rights => {
-    val validCase1 = isApplicationCreator(application)(rights)
-    val validCase2 = isAdmin(rights)
-    val validCase3 =
-      (isInstructor(rights) || isHelper(rights)) && not(isExpert(application.area)(rights)) &&
-        isInvitedOn(application)(rights)
-    val validCase4 = isExpert(application.area)(rights) && isInvitedOn(application)(rights) && not(
-      application.closed
-    )
-    validCase1 || validCase2 || validCase3 || validCase4
-  }
+  def canSeeApplication(application: Application): Check =
+    rights => {
+      val validCase1 = isApplicationCreator(application)(rights)
+      val validCase2 = isAdmin(rights)
+      val validCase3 =
+        (isInstructor(rights) || isHelper(rights)) && not(isExpert(application.area)(rights)) &&
+          isInvitedOn(application)(rights)
+      val validCase4 =
+        isExpert(application.area)(rights) && isInvitedOn(application)(rights) && not(
+          application.closed
+        )
+      validCase1 || validCase2 || validCase3 || validCase4
+    }
 
-  def canSeePrivateDataOfApplication(application: Application): Check = rights => {
-    val isCreatorOrIsInvited = isInvitedOn(application)(rights) || isApplicationCreator(
-      application
-    )(rights)
-    val validCase1 = isCreatorOrIsInvited && !isAdmin(rights)
-    // If user is expert, admin and invited to the application he can see the data
-    val validCase2 =
-      isCreatorOrIsInvited && isExpert(application.area)(rights) && isAdmin(rights) && not(
-        application.closed
-      )
-    validCase1 || validCase2
-  }
+  def canSeePrivateDataOfApplication(application: Application): Check =
+    rights => {
+      val isCreatorOrIsInvited = isInvitedOn(application)(rights) || isApplicationCreator(
+        application
+      )(rights)
+      val validCase1 = isCreatorOrIsInvited && !isAdmin(rights)
+      // If user is expert, admin and invited to the application he can see the data
+      val validCase2 =
+        isCreatorOrIsInvited && isExpert(application.area)(rights) && isAdmin(rights) && not(
+          application.closed
+        )
+      validCase1 || validCase2
+    }
 
 }

--- a/app/models/Event.scala
+++ b/app/models/Event.scala
@@ -23,4 +23,5 @@ case class Event(
       s"${description.filterNot(stripChars contains _)} ${ipAddress} ${id} ${fromUserId} ${toApplicationId
         .getOrElse("")} ${toUserId.getOrElse("")}"
   }
+
 }

--- a/app/models/LoginToken.scala
+++ b/app/models/LoginToken.scala
@@ -27,4 +27,5 @@ object LoginToken {
       Time.nowParis().plusMinutes(expirationInMinutes.toLong),
       ipAddress
     )
+
 }

--- a/app/models/Organisation.scala
+++ b/app/models/Organisation.scala
@@ -23,6 +23,7 @@ object Organisation {
 
       override def unbind(key: String, value: Organisation.Id) =
         Map(key -> value.id)
+
     }
 
     implicit val organisationIdAnormParser: anorm.Column[Organisation.Id] =
@@ -30,11 +31,12 @@ object Organisation {
 
   }
 
-  def apply(shortName: String, name: String): Organisation = Organisation(
-    id = Organisation.Id(shortName),
-    shortName = shortName,
-    name = name
-  )
+  def apply(shortName: String, name: String): Organisation =
+    Organisation(
+      id = Organisation.Id(shortName),
+      shortName = shortName,
+      name = name
+    )
 
   def isValidId(id: Organisation.Id): Boolean =
     byId(id).nonEmpty
@@ -97,4 +99,5 @@ object Organisation {
         lowerCaseName.contains(organisation.name.toLowerCase().stripSpecialChars)
       }
   }
+
 }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -43,6 +43,7 @@ case class User(
   // TODO: put this in Authorization
   def canSeeUsersInArea(areaId: UUID): Boolean =
     (areaId == Area.allArea.id || areas.contains(areaId)) && (admin || groupAdmin)
+
 }
 
 object User {
@@ -133,4 +134,5 @@ object User {
       cguAcceptationDate = Some(date)
     )
   )
+
 }

--- a/app/serializers/Anorm.scala
+++ b/app/serializers/Anorm.scala
@@ -78,6 +78,7 @@ object Anorm {
       jsonObject.setValue(Json.stringify(v))
       s.setObject(index, jsonObject)
     }
+
   }
 
   implicit val columnToJson: Column[JsValue] = Column.nonNull { (value, meta) =>

--- a/app/serializers/DataModel.scala
+++ b/app/serializers/DataModel.scala
@@ -23,6 +23,9 @@ object DataModel {
           case "paper" => Some(Paper)
           case _       => None
         }
+
     }
+
   }
+
 }

--- a/app/serializers/JsonFormats.scala
+++ b/app/serializers/JsonFormats.scala
@@ -16,6 +16,7 @@ object JsonFormats {
         case (k, v) =>
           UUIDHelper.fromString(k).get -> v.asInstanceOf[String]
       })
+
   }
 
   implicit val mapUUIDWrites = new Writes[Map[UUID, String]] {
@@ -26,6 +27,7 @@ object JsonFormats {
           val ret: (String, JsValueWrapper) = s.toString -> JsString(o)
           ret
       }.toSeq: _*)
+
   }
 
   implicit val mapUUIDFormat = Format(mapUUIDReads, mapUUIDWrites)

--- a/app/serializers/UserAndGroupCsvSerializer.scala
+++ b/app/serializers/UserAndGroupCsvSerializer.scala
@@ -24,6 +24,7 @@ object UserAndGroupCsvSerializer {
 
   val USER_EMAIL =
     Header("user.email", List("Email", "Adresse e-mail", "Contact mail Agent", "MAIL"))
+
   val USER_INSTRUCTOR = Header("user.instructor", List("Instructeur"))
   val USER_GROUP_MANAGER = Header("user.admin-group", List("Responsable"))
   val USER_QUALITY = Header("user.quality", List("Qualité"))
@@ -32,7 +33,12 @@ object UserAndGroupCsvSerializer {
 
   val GROUP_AREAS_IDS = Header("group.area-ids", List("Territoire", "DEPARTEMENTS"))
   val GROUP_ORGANISATION = Header("group.organisation", List("Organisation"))
-  val GROUP_NAME = Header("group.name", List("Groupe", "Opérateur partenaire")) // "Nom de la structure labellisable"
+
+  val GROUP_NAME =
+    Header(
+      "group.name",
+      List("Groupe", "Opérateur partenaire")
+    ) // "Nom de la structure labellisable"
   val GROUP_EMAIL = Header("group.email", List("Bal", "adresse mail générique"))
 
   val SEPARATOR = ";"
@@ -46,6 +52,7 @@ object UserAndGroupCsvSerializer {
     USER_GROUP_MANAGER,
     USER_ACCOUNT_IS_SHARED
   )
+
   val USER_HEADER = USER_HEADERS.map(_.prefixes(0)).mkString(SEPARATOR)
 
   val GROUP_HEADERS = List(GROUP_NAME, GROUP_ORGANISATION, GROUP_EMAIL, GROUP_AREAS_IDS)
@@ -318,51 +325,61 @@ object UserAndGroupCsvSerializer {
                   )
               )
         )
+
   }
 
-  private def userCSVMapping(currentDate: ZonedDateTime): Mapping[User] = single(
-    "user" -> mapping(
-      "id" -> optional(uuid).transform[UUID]({
-        case None     => UUID.randomUUID()
-        case Some(id) => id
-      }, Some(_)),
-      "key" -> ignored("key"),
-      "name" -> nonEmptyText,
-      "quality" -> default(text, ""),
-      "email" -> nonEmptyText,
-      "helper" -> ignored(true),
-      "instructor" -> boolean,
-      "admin" -> ignored(false),
-      "area-ids" -> ignored(List.empty[UUID]),
-      "creationDate" -> ignored(currentDate),
-      "communeCode" -> ignored("0"),
-      "admin-group" -> boolean,
-      "disabled" -> ignored(false),
-      "expert" -> ignored(false),
-      "groupIds" -> default(list(uuid), Nil),
-      "cguAcceptationDate" -> ignored(Option.empty[ZonedDateTime]),
-      "newsletterAcceptationDate" -> ignored(Option.empty[ZonedDateTime]),
-      "phone-number" -> optional(text),
-      // TODO: put in CSV?
-      "observableOrganisationIds" -> list(of[Organisation.Id]),
-      Keys.User.sharedAccount -> boolean
-    )(User.apply)(User.unapply)
-  )
-
-  private def groupCSVMapping(currentDate: ZonedDateTime): Mapping[UserGroup] = single(
-    "group" ->
-      mapping(
-        "id" -> optional(uuid).transform[UUID]({
-          case None     => UUID.randomUUID()
-          case Some(id) => id
-        }, Some(_)),
-        "name" -> text,
-        "description" -> optional(text),
-        "insee-code" -> list(text),
+  private def userCSVMapping(currentDate: ZonedDateTime): Mapping[User] =
+    single(
+      "user" -> mapping(
+        "id" -> optional(uuid).transform[UUID](
+          {
+            case None     => UUID.randomUUID()
+            case Some(id) => id
+          },
+          Some(_)
+        ),
+        "key" -> ignored("key"),
+        "name" -> nonEmptyText,
+        "quality" -> default(text, ""),
+        "email" -> nonEmptyText,
+        "helper" -> ignored(true),
+        "instructor" -> boolean,
+        "admin" -> ignored(false),
+        "area-ids" -> ignored(List.empty[UUID]),
         "creationDate" -> ignored(currentDate),
-        "area-ids" -> list(uuid),
-        "organisation" -> optional(of[Organisation.Id]),
-        "email" -> optional(email)
-      )(UserGroup.apply)(UserGroup.unapply)
-  )
+        "communeCode" -> ignored("0"),
+        "admin-group" -> boolean,
+        "disabled" -> ignored(false),
+        "expert" -> ignored(false),
+        "groupIds" -> default(list(uuid), Nil),
+        "cguAcceptationDate" -> ignored(Option.empty[ZonedDateTime]),
+        "newsletterAcceptationDate" -> ignored(Option.empty[ZonedDateTime]),
+        "phone-number" -> optional(text),
+        // TODO: put in CSV?
+        "observableOrganisationIds" -> list(of[Organisation.Id]),
+        Keys.User.sharedAccount -> boolean
+      )(User.apply)(User.unapply)
+    )
+
+  private def groupCSVMapping(currentDate: ZonedDateTime): Mapping[UserGroup] =
+    single(
+      "group" ->
+        mapping(
+          "id" -> optional(uuid).transform[UUID](
+            {
+              case None     => UUID.randomUUID()
+              case Some(id) => id
+            },
+            Some(_)
+          ),
+          "name" -> text,
+          "description" -> optional(text),
+          "insee-code" -> list(text),
+          "creationDate" -> ignored(currentDate),
+          "area-ids" -> list(uuid),
+          "organisation" -> optional(of[Organisation.Id]),
+          "email" -> optional(email)
+        )(UserGroup.apply)(UserGroup.unapply)
+    )
+
 }

--- a/app/services/ApplicationService.scala
+++ b/app/services/ApplicationService.scala
@@ -108,11 +108,12 @@ class ApplicationService @Inject() (
       }
     }
 
-  def openAndOlderThan(day: Int) = db.withConnection { implicit connection =>
-    SQL(
-      s"SELECT * FROM application WHERE closed = false AND age(creation_date) > '$day days' AND expert_invited = false"
-    ).as(simpleApplication.*)
-  }
+  def openAndOlderThan(day: Int) =
+    db.withConnection { implicit connection =>
+      SQL(
+        s"SELECT * FROM application WHERE closed = false AND age(creation_date) > '$day days' AND expert_invited = false"
+      ).as(simpleApplication.*)
+    }
 
   def allOpenOrRecentForUserId(
       userId: UUID,
@@ -133,17 +134,18 @@ class ApplicationService @Inject() (
       }
     }
 
-  def allForUserId(userId: UUID, anonymous: Boolean) = db.withConnection { implicit connection =>
-    val result = SQL(
-      "SELECT * FROM application WHERE creator_user_id = {userId}::uuid OR invited_users ?? {userId} ORDER BY creation_date DESC"
-    ).on("userId" -> userId)
-      .as(simpleApplication.*)
-    if (anonymous) {
-      result.map(_.anonymousApplication)
-    } else {
-      result
+  def allForUserId(userId: UUID, anonymous: Boolean) =
+    db.withConnection { implicit connection =>
+      val result = SQL(
+        "SELECT * FROM application WHERE creator_user_id = {userId}::uuid OR invited_users ?? {userId} ORDER BY creation_date DESC"
+      ).on("userId" -> userId)
+        .as(simpleApplication.*)
+      if (anonymous) {
+        result.map(_.anonymousApplication)
+      } else {
+        result
+      }
     }
-  }
 
   def allForUserIds(userIds: List[UUID]): Future[List[Application]] =
     Future {
@@ -154,8 +156,8 @@ class ApplicationService @Inject() (
       }
     }
 
-  def allForCreatorUserId(creatorUserId: UUID, anonymous: Boolean) = db.withConnection {
-    implicit connection =>
+  def allForCreatorUserId(creatorUserId: UUID, anonymous: Boolean) =
+    db.withConnection { implicit connection =>
       val result = SQL(
         "SELECT * FROM application WHERE creator_user_id = {creatorUserId}::uuid ORDER BY creation_date DESC"
       ).on("creatorUserId" -> creatorUserId)
@@ -165,10 +167,10 @@ class ApplicationService @Inject() (
       } else {
         result
       }
-  }
+    }
 
-  def allForInvitedUserId(invitedUserId: UUID, anonymous: Boolean) = db.withConnection {
-    implicit connection =>
+  def allForInvitedUserId(invitedUserId: UUID, anonymous: Boolean) =
+    db.withConnection { implicit connection =>
       val result = SQL(
         "SELECT * FROM application WHERE invited_users ?? {invitedUserId} ORDER BY creation_date DESC"
       ).on("invitedUserId" -> invitedUserId)
@@ -178,19 +180,20 @@ class ApplicationService @Inject() (
       } else {
         result
       }
-  }
-
-  def allByArea(areaId: UUID, anonymous: Boolean) = db.withConnection { implicit connection =>
-    val result =
-      SQL("SELECT * FROM application WHERE area = {areaId}::uuid ORDER BY creation_date DESC")
-        .on("areaId" -> areaId)
-        .as(simpleApplication.*)
-    if (anonymous) {
-      result.map(_.anonymousApplication)
-    } else {
-      result
     }
-  }
+
+  def allByArea(areaId: UUID, anonymous: Boolean) =
+    db.withConnection { implicit connection =>
+      val result =
+        SQL("SELECT * FROM application WHERE area = {areaId}::uuid ORDER BY creation_date DESC")
+          .on("areaId" -> areaId)
+          .as(simpleApplication.*)
+      if (anonymous) {
+        result.map(_.anonymousApplication)
+      } else {
+        result
+      }
+    }
 
   def allForAreas(areaIds: List[UUID]): Future[List[Application]] =
     Future {
@@ -201,20 +204,22 @@ class ApplicationService @Inject() (
       }
     }
 
-  def all(): Future[List[Application]] = Future {
-    db.withConnection { implicit connection =>
-      SQL"""SELECT * FROM application""".as(simpleApplication.*).map(_.anonymousApplication)
+  def all(): Future[List[Application]] =
+    Future {
+      db.withConnection { implicit connection =>
+        SQL"""SELECT * FROM application""".as(simpleApplication.*).map(_.anonymousApplication)
+      }
     }
-  }
 
-  def createApplication(newApplication: Application) = db.withConnection { implicit connection =>
-    val invitedUserJson = Json.toJson(newApplication.invitedUsers.map {
-      case (key, value) =>
-        key.toString -> value
-    })
-    val mandatType =
-      newApplication.mandatType.map(DataModel.Application.MandatType.dataModelSerialization)
-    SQL"""
+  def createApplication(newApplication: Application) =
+    db.withConnection { implicit connection =>
+      val invitedUserJson = Json.toJson(newApplication.invitedUsers.map {
+        case (key, value) =>
+          key.toString -> value
+      })
+      val mandatType =
+        newApplication.mandatType.map(DataModel.Application.MandatType.dataModelSerialization)
+      SQL"""
           INSERT INTO application (
             id,
             creation_date,
@@ -247,7 +252,7 @@ class ApplicationService @Inject() (
             ${newApplication.mandatDate}
           )
       """.executeUpdate() == 1
-  }
+    }
 
   def add(applicationId: UUID, answer: Answer, expertInvited: Boolean = false) =
     db.withTransaction { implicit connection =>
@@ -293,4 +298,5 @@ class ApplicationService @Inject() (
         )
         .executeUpdate() == 1
     }
+
 }

--- a/app/services/AttachmentService.scala
+++ b/app/services/AttachmentService.scala
@@ -94,4 +94,5 @@ object AttachmentHelper {
         Some(attachmentName -> f.length())
     }
   }
+
 }

--- a/app/services/EventService.scala
+++ b/app/services/EventService.scala
@@ -102,8 +102,8 @@ class EventService @Inject() (db: Database) {
       """.executeUpdate() == 1
     }
 
-  def all(limit: Int = 1000, fromUserId: Option[UUID] = None) = db.withConnection {
-    implicit connection =>
+  def all(limit: Int = 1000, fromUserId: Option[UUID] = None) =
+    db.withConnection { implicit connection =>
       fromUserId match {
         case Some(userId) =>
           SQL"""SELECT *, host(ip_address)::TEXT AS ip_address FROM "event" WHERE from_user_id = $userId::uuid OR to_user_id = $userId::uuid ORDER BY creation_date DESC LIMIT $limit"""
@@ -112,5 +112,6 @@ class EventService @Inject() (db: Database) {
           SQL"""SELECT *, host(ip_address)::TEXT AS ip_address FROM "event" ORDER BY creation_date DESC LIMIT $limit"""
             .as(simpleEvent.*)
       }
-  }
+    }
+
 }

--- a/app/services/NotificationService.scala
+++ b/app/services/NotificationService.scala
@@ -179,8 +179,8 @@ class NotificationService @Inject() (
     val bodyHtml = s"""Bonjour ${invitedUser.name},<br>
                       |<br>
                       |<p>${answer
-                        .map(_.creatorUserName)
-                        .getOrElse(application.creatorUserName)} a besoin de vous.<br>
+      .map(_.creatorUserName)
+      .getOrElse(application.creatorUserName)} a besoin de vous.<br>
                       |Cette personne vous a invité sur la demande suivante : "${application.subject}"
                       |Vous pouvez voir la demande et y répondre en suivant ce lien : <br>
                       |<a href="${url}">${url}</a><br>
@@ -218,4 +218,5 @@ class NotificationService @Inject() (
       bodyHtml = Some(bodyHtml)
     )
   }
+
 }

--- a/app/services/OrganisationService.scala
+++ b/app/services/OrganisationService.scala
@@ -18,12 +18,15 @@ object OrganisationService {
         YamlString(x.shortName)
       }
 
-      def read(value: YamlValue) = value match {
-        case YamlString(x) => Organisation.fromShortName(x).get
-        case x =>
-          deserializationError("Expected String as YamlString, but got " + x)
-      }
+      def read(value: YamlValue) =
+        value match {
+          case YamlString(x) => Organisation.fromShortName(x).get
+          case x =>
+            deserializationError("Expected String as YamlString, but got " + x)
+        }
+
     }
+
     implicit val subjectFormat = yamlFormat2(Subject.apply)
     implicit val categoryFormat = yamlFormat4(Category.apply)
   }
@@ -44,6 +47,7 @@ object OrganisationService {
       contactMail: Option[String],
       phone: Option[String]
   )
+
   case class FranceServiceInfos(instances: List[FranceServiceInstance])
 
 }

--- a/app/tasks/AutoAddExpertTask.scala
+++ b/app/tasks/AutoAddExpertTask.scala
@@ -83,4 +83,5 @@ class AutoAddExpertTask @Inject() (
       }
     }
   }
+
 }

--- a/app/tasks/RemoveExpiredFilesTask.scala
+++ b/app/tasks/RemoveExpiredFilesTask.scala
@@ -42,4 +42,5 @@ class RemoveExpiredFilesTask @Inject() (
       fileToDelete.foreach(_.delete())
     }
   }
+
 }

--- a/app/views/home/LoginPanel.scala
+++ b/app/views/home/LoginPanel.scala
@@ -14,4 +14,5 @@ object LoginPanel {
       tokenExpirationInMinutes: Int,
       successMessage: Option[String]
   ) extends LoginPanel
+
 }


### PR DESCRIPTION
L'update de scalafmt 2.4 => 2.5 casse le formattage.

* scalafmt arrête de supporter le versioning sémantique https://scalameta.org/scalafmt/docs/changelog.html
* j'ai revert un nouveau défault qu'ils ont changé `rewrite.redundantBraces.generalExpressions = false` car il fait que 2 branches d'un `if then else` peuvent utiliser les accolades de façon différentes
* j'ai gardé les autres nouveaux défaults
* j'ai rajouté (nouvelles options) `newlines.topLevelStatements = [before, after]` et `trailingCommas = preserve`

@jdauphant comme le formattage est cassé, c'est le moment d'ajouter des options si tu veux, on essaiera de trouver un "bon" moment pour merge, quand il n'y aura plus de PR