### PR TITLE
Corrige une exception dans les emails avec des noms avec des caractères spéciaux

### DIFF
--- a/app/helper/EmailHelper.scala
+++ b/app/helper/EmailHelper.scala
@@ -1,0 +1,37 @@
+package helper
+
+object EmailHelper {
+
+  /** In the creation of the email, the raw strings in `play.api.libs.mailer.Email` that are
+    * supposed to be email addresses are sent without escaping to the constructor of the class
+    * `javax.mail.internet.InternetAddress` which will throw an exception for ill-formatted strings.
+    * Address spec: https://tools.ietf.org/html/rfc822#section-6
+    * We want to avoid invalid `phrase`: https://tools.ietf.org/html/rfc822#section-3.3
+    *
+    * Useful bits of the BNF:
+    *      phrase      =  1*word                       ; Sequence of words
+    *      word        =  atom / quoted-string
+    *      atom        =  1*<any CHAR except specials, SPACE and CTLs>
+    *      quoted-string = <"> *(qtext/quoted-pair) <">; Regular qtext or
+    *      qtext       =  <any CHAR excepting <">,     ; => may be folded
+    *                      "\" & CR, and including
+    *                      linear-white-space>
+    *
+    * Note: this implementation is not at all RFC complient.
+    *       It should pass the constructor of `InternetAddress`.
+    */
+  def quoteEmailPhrase(phrase: String): String = {
+    // Remove controls
+    val noControls = """\p{Cc}""".r.replaceAllIn(phrase, "")
+    val specialsOrSpace =
+      Set[Char]('(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '.', '[', ']', ' ')
+    val mustBeQuoted = noControls.exists(specialsOrSpace.contains)
+    if (mustBeQuoted) {
+      val noQuotesNorBackslashes = """[\\"]""".r.replaceAllIn(noControls, "")
+      "\"" + noQuotesNorBackslashes + "\""
+    } else {
+      noControls
+    }
+  }
+
+}

--- a/app/services/NotificationService.scala
+++ b/app/services/NotificationService.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import constants.Constants
 import javax.inject.{Inject, Singleton}
 import controllers.routes
+import helper.EmailHelper.quoteEmailPhrase
 import models._
 import models.mandat.Mandat
 import play.api.Logger
@@ -120,7 +121,7 @@ class NotificationService @Inject() (
     val email = play.api.libs.mailer.Email(
       s"Connexion à Administration+",
       from = from,
-      Seq(s"${user.name} <${user.email}>"),
+      Seq(s"${quoteEmailPhrase(user.name)} <${user.email}>"),
       bodyHtml = Some(bodyHtml)
     )
     sendMail(email)
@@ -162,7 +163,7 @@ class NotificationService @Inject() (
     Email(
       subject = subject,
       from = from,
-      to = List(s"${group.name} <${group.email.get}>"),
+      to = List(s"${quoteEmailPhrase(group.name)} <${group.email.get}>"),
       bodyHtml = Some(bodyHtml)
     )
   }
@@ -172,7 +173,7 @@ class NotificationService @Inject() (
     Email(
       subject = "[A+] Bienvenue sur Administration+",
       from = from,
-      to = List(s"${user.name} <${user.email}>"),
+      to = List(s"${quoteEmailPhrase(user.name)} <${user.email}>"),
       bodyHtml = Some(bodyHtml)
     )
   }
@@ -196,7 +197,7 @@ class NotificationService @Inject() (
     Email(
       subject = s"[A+] Nouvelle demande d'aide : ${application.subject}",
       from = from,
-      to = List(s"${invitedUser.name} <${invitedUser.email}>"),
+      to = List(s"${quoteEmailPhrase(invitedUser.name)} <${invitedUser.email}>"),
       bodyHtml = Some(bodyHtml)
     )
   }
@@ -221,7 +222,7 @@ class NotificationService @Inject() (
     Email(
       subject = s"[A+] Nouvelle réponse pour : ${application.subject}",
       from = from,
-      to = List(s"${user.name} <${user.email}>"),
+      to = List(s"${quoteEmailPhrase(user.name)} <${user.email}>"),
       bodyHtml = Some(bodyHtml)
     )
   }
@@ -245,7 +246,7 @@ class NotificationService @Inject() (
     Email(
       subject = subject,
       from = from,
-      to = List(s"${user.name} <${user.email}>"),
+      to = List(s"${quoteEmailPhrase(user.name)} <${user.email}>"),
       bodyHtml = Some(bodyHtml.toString)
     )
   }
@@ -266,7 +267,7 @@ class NotificationService @Inject() (
     Email(
       subject = subject,
       from = from,
-      to = List(s"${user.name} <${user.email}>"),
+      to = List(s"${quoteEmailPhrase(user.name)} <${user.email}>"),
       bodyHtml = Some(bodyHtml.toString)
     )
   }


### PR DESCRIPTION
Fix https://sentry.data.gouv.fr/aplusbetagouvfr/aplus-prod-worldline/issues/1883351/
AddressException
Local address contains control or whitespace