### PR TITLE
Ajoute un filtre par date de la liste des events. Service passé en non bloquant.

### DIFF
--- a/app/controllers/GroupController.scala
+++ b/app/controllers/GroupController.scala
@@ -29,6 +29,7 @@ import models.EventType.{
   UserGroupDeletionUnauthorized,
   UserGroupEdited
 }
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 case class GroupController @Inject() (
@@ -39,63 +40,70 @@ case class GroupController @Inject() (
     configuration: Configuration,
     ws: WSClient,
     userService: UserService
-)(implicit val webJarsUtil: WebJarsUtil)
+)(implicit ec: ExecutionContext, webJarsUtil: WebJarsUtil)
     extends InjectedController
     with GroupOperators
     with UserOperators {
 
-  def deleteUnusedGroupById(groupId: UUID): Action[AnyContent] = loginAction { implicit request =>
-    withGroup(groupId) { group: UserGroup =>
-      asAdminOfGroupZone(group) { () =>
-        GroupDeletionUnauthorized -> s"Droits insuffisants pour la suppression du groupe ${groupId}."
-      } { () =>
-        val empty = groupService.isGroupEmpty(group.id)
-        if (not(empty)) {
-          eventService.log(
-            UserGroupDeletionUnauthorized,
-            description = "Tentative de suppression d'un groupe utilisé."
-          )
-          Unauthorized("Group is not unused.")
-        } else {
-          groupService.deleteById(groupId)
-          eventService.log(UserGroupDeleted, s"Suppression du groupe ${groupId}.")
-          Redirect(
-            routes.UserController.all(group.areaIds.headOption.getOrElse(Area.allArea.id)),
-            303
-          )
+  def deleteUnusedGroupById(groupId: UUID): Action[AnyContent] = loginAction.async {
+    implicit request =>
+      withGroup(groupId) { group: UserGroup =>
+        asAdminOfGroupZone(group) { () =>
+          GroupDeletionUnauthorized -> s"Droits insuffisants pour la suppression du groupe ${groupId}."
+        } { () =>
+          val empty = groupService.isGroupEmpty(group.id)
+          if (not(empty)) {
+            eventService.log(
+              UserGroupDeletionUnauthorized,
+              description = "Tentative de suppression d'un groupe utilisé."
+            )
+            Future(Unauthorized("Group is not unused."))
+          } else {
+            groupService.deleteById(groupId)
+            eventService.log(UserGroupDeleted, s"Suppression du groupe ${groupId}.")
+            Future(
+              Redirect(
+                routes.UserController.all(group.areaIds.headOption.getOrElse(Area.allArea.id)),
+                303
+              )
+            )
+          }
         }
       }
-    }
   }
 
-  def editGroup(id: UUID): Action[AnyContent] = loginAction { implicit request =>
+  def editGroup(id: UUID): Action[AnyContent] = loginAction.async { implicit request =>
     withGroup(id) { group: UserGroup =>
       if (!group.canHaveUsersAddedBy(request.currentUser)) {
         eventService.log(EditGroupUnauthorized, s"Accès non autorisé à l'edition de ce groupe")
-        Unauthorized("Vous ne pouvez pas éditer ce groupe : êtes-vous dans la bonne zone ?")
+        Future(Unauthorized("Vous ne pouvez pas éditer ce groupe : êtes-vous dans la bonne zone ?"))
       } else {
         val groupUsers = userService.byGroupIds(List(id))
         eventService.log(EditGroupShowed, s"Visualise la vue de modification du groupe")
         val isEmpty = groupService.isGroupEmpty(group.id)
-        Ok(
-          views.html.editGroup(request.currentUser, request.rights)(
-            group,
-            groupUsers,
-            isEmpty
+        Future(
+          Ok(
+            views.html.editGroup(request.currentUser, request.rights)(
+              group,
+              groupUsers,
+              isEmpty
+            )
           )
         )
       }
     }
   }
 
-  def addGroup(): Action[AnyContent] = loginAction { implicit request =>
+  def addGroup(): Action[AnyContent] = loginAction.async { implicit request =>
     asAdmin(() => AddGroupUnauthorized -> s"Accès non autorisé pour ajouter un groupe") { () =>
       addGroupForm(Time.timeZoneParis).bindFromRequest.fold(
         formWithErrors => {
           eventService
             .log(AddUserGroupError, s"Essai d'ajout d'un groupe avec des erreurs de validation")
-          Redirect(routes.UserController.home).flashing(
-            "error" -> s"Impossible d'ajouter le groupe : ${formWithErrors.errors.mkString}"
+          Future(
+            Redirect(routes.UserController.home).flashing(
+              "error" -> s"Impossible d'ajouter le groupe : ${formWithErrors.errors.mkString}"
+            )
           )
         },
         group =>
@@ -104,22 +112,26 @@ case class GroupController @Inject() (
             .fold(
               { error: String =>
                 eventService.log(AddUserGroupError, s"Impossible d'ajouter le groupe dans la BDD")
-                Redirect(routes.UserController.home)
-                  .flashing("error" -> s"Impossible d'ajouter le groupe : $error")
-              }, { Unit =>
+                Future(
+                  Redirect(routes.UserController.home)
+                    .flashing("error" -> s"Impossible d'ajouter le groupe : $error")
+                )
+              }, { _ =>
                 eventService.log(
                   UserGroupCreated,
                   s"Groupe ${group.name} (id : ${group.id}) ajouté par l'utilisateur d'id ${request.currentUser.id}"
                 )
-                Redirect(routes.GroupController.editGroup(group.id))
-                  .flashing("success" -> "Groupe ajouté")
+                Future(
+                  Redirect(routes.GroupController.editGroup(group.id))
+                    .flashing("success" -> "Groupe ajouté")
+                )
               }
             )
       )
     }
   }
 
-  def editGroupPost(groupId: UUID): Action[AnyContent] = loginAction { implicit request =>
+  def editGroupPost(groupId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
     asAdmin(() => EditGroupUnauthorized -> s"Accès non autorisé à l'edition de ce groupe") { () =>
       withGroup(groupId) { currentGroup: UserGroup =>
         if (not(currentGroup.canHaveUsersAddedBy(request.currentUser))) {
@@ -127,7 +139,7 @@ case class GroupController @Inject() (
             AddUserToGroupUnauthorized,
             s"L'utilisateur ${request.currentUser.id} n'est pas authorisé à ajouter des utilisateurs au groupe ${currentGroup.id}."
           )
-          Unauthorized("Vous n'êtes pas authorisé à ajouter des utilisateurs à ce groupe.")
+          Future(Unauthorized("Vous n'êtes pas authorisé à ajouter des utilisateurs à ce groupe."))
         } else {
           addGroupForm(Time.timeZoneParis).bindFromRequest.fold(
             formWithError => {
@@ -135,22 +147,28 @@ case class GroupController @Inject() (
                 EditUserGroupError,
                 s"Essai d'edition d'un groupe avec des erreurs de validation"
               )
-              Redirect(routes.GroupController.editGroup(groupId)).flashing(
-                "error" -> s"Impossible de modifier le groupe (erreur de formulaire) : ${formWithError.errors.mkString}"
+              Future(
+                Redirect(routes.GroupController.editGroup(groupId)).flashing(
+                  "error" -> s"Impossible de modifier le groupe (erreur de formulaire) : ${formWithError.errors.mkString}"
+                )
               )
             },
             group =>
               if (groupService.edit(group.copy(id = groupId))) {
                 eventService.log(UserGroupEdited, s"Groupe édité")
-                Redirect(routes.GroupController.editGroup(groupId))
-                  .flashing("success" -> "Groupe modifié")
+                Future(
+                  Redirect(routes.GroupController.editGroup(groupId))
+                    .flashing("success" -> "Groupe modifié")
+                )
               } else {
                 eventService
                   .log(EditUserGroupError, s"Impossible de modifier le groupe dans la BDD")
-                Redirect(routes.GroupController.editGroup(groupId))
-                  .flashing(
-                    "error" -> "Impossible de modifier le groupe: erreur en base de donnée"
-                  )
+                Future(
+                  Redirect(routes.GroupController.editGroup(groupId))
+                    .flashing(
+                      "error" -> "Impossible de modifier le groupe: erreur en base de donnée"
+                    )
+                )
               }
           )
         }

--- a/app/controllers/Operators.scala
+++ b/app/controllers/Operators.scala
@@ -22,22 +22,24 @@ object Operators {
 
     def withGroup(
         groupId: UUID
-    )(payload: UserGroup => Result)(implicit request: RequestWithUserData[AnyContent]): Result =
+    )(
+        payload: UserGroup => Future[Result]
+    )(implicit request: RequestWithUserData[AnyContent], ec: ExecutionContext): Future[Result] =
       groupService
         .groupById(groupId)
         .fold({
           eventService
             .log(UserGroupNotFound, description = "Tentative d'accès à un groupe inexistant.")
-          NotFound("Groupe inexistant.")
+          Future(NotFound("Groupe inexistant."))
         })({ group: UserGroup => payload(group) })
 
     def asAdminOfGroupZone(group: UserGroup)(event: () => (EventType, String))(
-        payload: () => Result
-    )(implicit request: RequestWithUserData[AnyContent]): Result =
+        payload: () => Future[Result]
+    )(implicit request: RequestWithUserData[AnyContent], ec: ExecutionContext): Future[Result] =
       if (not(request.currentUser.admin)) {
         val (eventType, description) = event()
         eventService.log(eventType, description = description)
-        Unauthorized("Vous n'avez pas le droit de faire ça")
+        Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
       } else {
         if (group.areaIds.forall(request.currentUser.areas.contains)) {
           payload()
@@ -46,7 +48,7 @@ object Operators {
             AdminOutOfRange,
             description = "L'administrateur n'est pas dans son périmètre de responsabilité."
           )
-          Unauthorized("Vous n'êtes pas en charge de la zone de ce groupe.")
+          Future(Unauthorized("Vous n'êtes pas en charge de la zone de ce groupe."))
         }
       }
   }
@@ -58,14 +60,14 @@ object Operators {
     import Results._
 
     def withUser(userId: UUID, includeDisabled: Boolean = false)(
-        payload: User => Result
-    )(implicit request: RequestWithUserData[AnyContent]): Result =
+        payload: User => Future[Result]
+    )(implicit request: RequestWithUserData[AnyContent], ec: ExecutionContext): Future[Result] =
       userService
         .byId(userId, includeDisabled)
         .fold({
           eventService
             .log(UserNotFound, description = "Tentative d'accès à un utilisateur inexistant.")
-          NotFound("Utilisateur inexistant.")
+          Future(NotFound("Utilisateur inexistant."))
         })({ user: User => payload(user) })
 
     def asUserWithAuthorization(authorizationCheck: Authorization.Check)(
@@ -82,12 +84,12 @@ object Operators {
       }
 
     def asAdmin(event: () => (EventType, String))(
-        payload: () => Result
-    )(implicit request: RequestWithUserData[AnyContent]): Result =
+        payload: () => Future[Result]
+    )(implicit request: RequestWithUserData[AnyContent], ec: ExecutionContext): Future[Result] =
       if (not(request.currentUser.admin)) {
         val (eventType, description) = event()
         eventService.log(eventType, description = description)
-        Unauthorized("Vous n'avez pas le droit de faire ça")
+        Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
       } else {
         payload()
       }
@@ -119,19 +121,19 @@ object Operators {
       }
 
     def asAdminOfUserZone(user: User)(event: () => (EventType, String))(
-        payload: () => Result
-    )(implicit request: RequestWithUserData[AnyContent]): Result =
+        payload: () => Future[Result]
+    )(implicit request: RequestWithUserData[AnyContent], ec: ExecutionContext): Future[Result] =
       if (not(request.currentUser.admin)) {
         val (eventType, description) = event()
         eventService.log(eventType, description = description)
-        Unauthorized("Vous n'avez pas le droit de faire ça")
+        Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
       } else {
         if (request.currentUser.areas.intersect(user.areas).isEmpty) {
           eventService.log(
             AdminOutOfRange,
             description = "L'administrateur n'est pas dans son périmètre de responsabilité."
           )
-          Unauthorized("Vous n'êtes pas en charge de la zone de cet utilisateur.")
+          Future(Unauthorized("Vous n'êtes pas en charge de la zone de cet utilisateur."))
         } else {
           payload()
         }

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import java.time.{ZoneId, ZonedDateTime}
+import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -240,25 +240,26 @@ case class UserController @Inject() (
   def isAccountUsed(user: User): Boolean =
     applicationService.allForUserId(userId = user.id, anonymous = false).nonEmpty
 
-  def deleteUnusedUserById(userId: UUID): Action[AnyContent] = loginAction { implicit request =>
-    withUser(userId, includeDisabled = true) { user: User =>
-      asAdminOfUserZone(user) { () =>
-        DeleteUserUnauthorized -> s"Suppression de l'utilisateur $userId refusée."
-      } { () =>
-        if (isAccountUsed(user)) {
-          eventService.log(UserIsUsed, description = s"Le compte ${user.id} est utilisé.")
-          Unauthorized("User is not unused.")
-        } else {
-          userService.deleteById(userId)
-          val message = s"Utilisateur $userId / ${user.email} a été supprimé"
-          eventService.log(UserDeleted, message, involvesUser = Some(user))
-          Redirect(controllers.routes.UserController.home).flashing("success" -> message)
+  def deleteUnusedUserById(userId: UUID): Action[AnyContent] = loginAction.async {
+    implicit request =>
+      withUser(userId, includeDisabled = true) { user: User =>
+        asAdminOfUserZone(user) { () =>
+          DeleteUserUnauthorized -> s"Suppression de l'utilisateur $userId refusée."
+        } { () =>
+          if (isAccountUsed(user)) {
+            eventService.log(UserIsUsed, description = s"Le compte ${user.id} est utilisé.")
+            Future(Unauthorized("User is not unused."))
+          } else {
+            userService.deleteById(userId)
+            val message = s"Utilisateur $userId / ${user.email} a été supprimé"
+            eventService.log(UserDeleted, message, involvesUser = Some(user))
+            Future(Redirect(controllers.routes.UserController.home).flashing("success" -> message))
+          }
         }
       }
-    }
   }
 
-  def editUserPost(userId: UUID): Action[AnyContent] = loginAction { implicit request =>
+  def editUserPost(userId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
     asAdmin(() => PostEditUserUnauthorized -> s"Accès non autorisé à modifier $userId") { () =>
       userForm(Time.timeZoneParis).bindFromRequest.fold(
         formWithErrors => {
@@ -267,8 +268,11 @@ case class UserController @Inject() (
             AddUserError,
             s"Essai de modification de l'utilisateur $userId avec des erreurs de validation"
           )
-          BadRequest(
-            views.html.editUser(request.currentUser, request.rights)(formWithErrors, userId, groups)
+          Future(
+            BadRequest(
+              views.html
+                .editUser(request.currentUser, request.rights)(formWithErrors, userId, groups)
+            )
           )
         },
         updatedUser =>
@@ -283,12 +287,14 @@ case class UserController @Inject() (
 
             if (not(Authorization.canEditOtherUser(user)(rights))) {
               eventService.log(PostEditUserUnauthorized, s"Accès non autorisé à modifier $userId")
-              Unauthorized("Vous n'avez pas le droit de faire ça")
+              Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
             } else if (userService.update(userToUpdate)) {
               eventService
                 .log(UserEdited, s"Utilisateur $userId modifié", involvesUser = Some(updatedUser))
-              Redirect(routes.UserController.editUser(userId))
-                .flashing("success" -> "Utilisateur modifié")
+              Future(
+                Redirect(routes.UserController.editUser(userId))
+                  .flashing("success" -> "Utilisateur modifié")
+              )
             } else {
               val form: Form[User] = userForm(Time.timeZoneParis)
                 .fill(userToUpdate)
@@ -301,8 +307,10 @@ case class UserController @Inject() (
                 "Impossible de modifier l'utilisateur dans la BDD",
                 involvesUser = Some(updatedUser)
               )
-              InternalServerError(
-                views.html.editUser(request.currentUser, request.rights)(form, userId, groups)
+              Future(
+                InternalServerError(
+                  views.html.editUser(request.currentUser, request.rights)(form, userId, groups)
+                )
               )
             }
           }
@@ -310,21 +318,23 @@ case class UserController @Inject() (
     }
   }
 
-  def addPost(groupId: UUID): Action[AnyContent] = loginAction { implicit request =>
+  def addPost(groupId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
     withGroup(groupId) { group: UserGroup =>
       if (!group.canHaveUsersAddedBy(request.currentUser)) {
         eventService.log(PostAddUserUnauthorized, "Accès non autorisé à l'admin des utilisateurs")
-        Unauthorized("Vous n'avez pas le droit de faire ça")
+        Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
       } else {
         usersForm(Time.timeZoneParis, group.areaIds).bindFromRequest.fold(
           { formWithErrors =>
             eventService
               .log(AddUserError, "Essai d'ajout d'utilisateurs avec des erreurs de validation")
-            BadRequest(
-              views.html.editUsers(request.currentUser, request.rights)(
-                formWithErrors,
-                0,
-                routes.UserController.addPost(groupId)
+            Future(
+              BadRequest(
+                views.html.editUsers(request.currentUser, request.rights)(
+                  formWithErrors,
+                  0,
+                  routes.UserController.addPost(groupId)
+                )
               )
             )
           },
@@ -342,15 +352,17 @@ case class UserController @Inject() (
                       val form = usersForm(Time.timeZoneParis, group.areaIds)
                         .fill(users)
                         .withGlobalError(errorMessage)
-                      InternalServerError(
-                        views.html.editUsers(request.currentUser, request.rights)(
-                          form,
-                          users.length,
-                          routes.UserController.addPost(groupId)
+                      Future(
+                        InternalServerError(
+                          views.html.editUsers(request.currentUser, request.rights)(
+                            form,
+                            users.length,
+                            routes.UserController.addPost(groupId)
+                          )
                         )
                       )
                   }, {
-                    Unit =>
+                    _ =>
                       users.foreach { user =>
                         notificationsService.newUser(user)
                         eventService.log(
@@ -360,8 +372,10 @@ case class UserController @Inject() (
                         )
                       }
                       eventService.log(UsersCreated, "Utilisateurs ajoutés")
-                      Redirect(routes.GroupController.editGroup(groupId))
-                        .flashing("success" -> "Utilisateurs ajoutés")
+                      Future(
+                        Redirect(routes.GroupController.editGroup(groupId))
+                          .flashing("success" -> "Utilisateurs ajoutés")
+                      )
                   }
                 )
             } catch {
@@ -380,11 +394,13 @@ case class UserController @Inject() (
                   AddUserError,
                   s"Impossible d'ajouter des utilisateurs dans la BDD : ${ex.getServerErrorMessage}"
                 )
-                BadRequest(
-                  views.html.editUsers(request.currentUser, request.rights)(
-                    form,
-                    users.length,
-                    routes.UserController.addPost(groupId)
+                Future(
+                  BadRequest(
+                    views.html.editUsers(request.currentUser, request.rights)(
+                      form,
+                      users.length,
+                      routes.UserController.addPost(groupId)
+                    )
                   )
                 )
             }
@@ -457,14 +473,14 @@ case class UserController @Inject() (
     )
   }
 
-  def add(groupId: UUID): Action[AnyContent] = loginAction { implicit request =>
+  def add(groupId: UUID): Action[AnyContent] = loginAction.async { implicit request =>
     withGroup(groupId) { group: UserGroup =>
       if (!group.canHaveUsersAddedBy(request.currentUser)) {
         eventService.log(
           ShowAddUserUnauthorized,
           s"Accès non autorisé à l'admin des utilisateurs du groupe $groupId"
         )
-        Unauthorized("Vous n'avez pas le droit de faire ça")
+        Future(Unauthorized("Vous n'avez pas le droit de faire ça"))
       } else {
         val rows =
           request
@@ -472,24 +488,33 @@ case class UserController @Inject() (
             .flatMap(rows => Try(rows.toInt).toOption)
             .getOrElse(1)
         eventService.log(EditUserShowed, "Visualise la vue d'ajouts des utilisateurs")
-        Ok(
-          views.html.editUsers(request.currentUser, request.rights)(
-            usersForm(Time.timeZoneParis, group.areaIds),
-            rows,
-            routes.UserController.addPost(groupId)
+        Future(
+          Ok(
+            views.html.editUsers(request.currentUser, request.rights)(
+              usersForm(Time.timeZoneParis, group.areaIds),
+              rows,
+              routes.UserController.addPost(groupId)
+            )
           )
         )
       }
     }
   }
 
-  def allEvents: Action[AnyContent] = loginAction { implicit request =>
+  def allEvents: Action[AnyContent] = loginAction.async { implicit request =>
     asAdmin(() => EventsUnauthorized -> "Accès non autorisé pour voir les événements") { () =>
-      val limit = request.getQueryString(Keys.QueryParam.limit).map(_.toInt).getOrElse(500)
+      val limit = request
+        .getQueryString(Keys.QueryParam.limit)
+        .flatMap(limit => Try(limit.toInt).toOption)
+        .getOrElse(500)
+      val date = request
+        .getQueryString(Keys.QueryParam.date)
+        .flatMap(date => Try(LocalDate.parse(date)).toOption)
       val userId = request.getQueryString(Keys.QueryParam.fromUserId).flatMap(UUIDHelper.fromString)
-      val events = eventService.all(limit, userId)
-      eventService.log(EventsShowed, s"Affiche les événements")
-      Ok(views.html.allEvents(request.currentUser, request.rights)(events, limit))
+      eventService.all(limit, userId, date).map { events =>
+        eventService.log(EventsShowed, s"Affiche les événements")
+        Ok(views.html.allEvents(request.currentUser, request.rights)(events, limit))
+      }
     }
   }
 

--- a/app/serializers/Keys.scala
+++ b/app/serializers/Keys.scala
@@ -50,6 +50,7 @@ object Keys {
     val rows: String = "rows"
     val limit: String = "limit"
     val fromUserId: String = "fromUserId"
+    val date: String = "date"
   }
 
 }


### PR DESCRIPTION
Changement fonctionnels : ajout du paramètre `date` dans `EventService.all` et du query parameter `date` dans `UserController.allEvents`.

J'ai passé `EventService.all` en non bloquant. Ça engendre quelques modifs avec des `Future` un peu partout. Notamment `Operators.scala` a maintenant toutes ses signatures 100% non bloquantes.