### PR TITLE
Corrige le label d’invitation d’un expert qui ne se voyait pas bien

### DIFF
--- a/app/views/showApplication.scala.html
+++ b/app/views/showApplication.scala.html
@@ -293,8 +293,8 @@ dialog {
                     not(application.closed) && not(application.expertInvited)) {
                     <div class="mdl-list__item">
                         <span class="mdl-list__item-primary-content">
-                            <button class="mdl-button mdl-button--raised mdl-js-button do-not-print" onclick="document.location = '@routes.ApplicationController.inviteExpert(application.id)'" style="margin-right: 10px;">
-                                Inviter un expert de l’équipe A+
+                            <button class="mdl-button mdl-button--raised mdl-js-button do-not-print single--white-space-nowrap" onclick="document.location = '@routes.ApplicationController.inviteExpert(application.id)'">
+                                Inviter un expert A+
                             </button>
                         </span>
                     </div>


### PR DESCRIPTION
avant
<img width="325" alt="Screen Shot 2020-07-13 at 20 17 02" src="https://user-images.githubusercontent.com/4394842/87339343-c2837880-c546-11ea-8530-cc24f1ee23ba.png">

après
<img width="324" alt="Screen Shot 2020-07-13 at 20 11 54" src="https://user-images.githubusercontent.com/4394842/87339370-c8795980-c546-11ea-9acf-51da61ad11a1.png">
