### PR TITLE
Permet aux aidants d’inviter des opérateurs

### DIFF
--- a/app/controllers/AreaController.scala
+++ b/app/controllers/AreaController.scala
@@ -37,25 +37,6 @@ case class AreaController @Inject() (
     .flatMap(UUIDHelper.fromString)
     .toList
 
-  @deprecated("You should not need area", "v0.1")
-  def change(areaId: UUID) = loginAction { implicit request =>
-    if (!request.currentUser.areas.contains[UUID](areaId)) {
-      eventService.log(ChangeAreaUnauthorized, s"Accès à la zone $areaId non autorisé")
-      Unauthorized(
-        s"Vous n'avez pas les droits suffisants pour accèder à cette zone. Vous pouvez contacter l'équipe A+ : ${Constants.supportEmail}"
-      )
-    } else {
-      eventService.log(AreaChanged, s"Changement vers la zone $areaId")
-      val redirect = request
-        .getQueryString("redirect")
-        .map(url => Redirect(url))
-        .getOrElse(Redirect(routes.ApplicationController.myApplications()))
-      redirect.withSession(
-        request.session - Keys.Session.areaId + (Keys.Session.areaId -> areaId.toString)
-      )
-    }
-  }
-
   def all = loginAction.async { implicit request =>
     if (!request.currentUser.admin && !request.currentUser.groupAdmin) {
       eventService.log(AllAreaUnauthorized, "Accès non autorisé pour voir la page des territoires")

--- a/app/serializers/Keys.scala
+++ b/app/serializers/Keys.scala
@@ -24,7 +24,6 @@ object Keys {
 
   object Session {
     val userId: String = "userId"
-    val areaId: String = "areaId"
   }
 
   //.queryString .getQueryString

--- a/app/views/createApplication.scala.html
+++ b/app/views/createApplication.scala.html
@@ -34,7 +34,7 @@
               <h5 class="title--addline">Territoire concerné</h5>
               <div>
                 @helpers.changeAreaSelect(currentArea, Area.all, routes.ApplicationController.create())
-                <em>(Le changement de territoire est une fonctionalité est expérimentale)</em>
+                <em>(Le changement de territoire est une fonctionalité expérimentale)</em>
               </div>
             } else if (currentUser.areas.nonEmpty) {
               <h5 class="title--addline">Territoire concerné</h5>

--- a/app/views/showApplication.scala.html
+++ b/app/views/showApplication.scala.html
@@ -1,6 +1,7 @@
 @import _root_.helper.Time
 @import _root_.helper.MDLForms._
 @import _root_.helper.BooleanHelper.not
+@import serializers.Keys
 
 
 @(currentUser: User, currentUserRights: Authorization.UserRights)(groupsWithUsersThatCanBeInvited: List[(UserGroup,List[User])], application: Application, answerToAgentsForm: Form[_], openedTab: String, currentArea: Area, userSignature: Option[String], attachments: Iterable[String] = Nil)(implicit webJarsUtil: org.webjars.play.WebJarsUtil, flash: Flash, messagesProvider: MessagesProvider, request: RequestHeader)
@@ -537,10 +538,16 @@ dialog {
                     @if(groupsWithUsersThatCanBeInvited.nonEmpty || currentUser.expert) {
                         <div class="mdl-tabs__panel @if(openedTab =="invite"){ is-active }" id="invite">
                             <form action='@routes.ApplicationController.invite(application.id)' class="mdl-cell mdl-cell--12-col mdl-grid aplus-protected-form" method="post">
+
+                                <input type="hidden"
+                                       name="@{Keys.Application.areaId}"
+                                       readonly
+                                       value="@{currentArea.id}">
+
                                 @if(currentUser.expert) {
                                     <div>
-                                        Territoire concerné :
-                                    @helpers.changeArea(currentArea, currentUser.areas.flatMap(Area.fromId))
+                                      Territoire concerné :
+                                      @helpers.changeAreaSelect(currentArea, currentUser.areas.flatMap(Area.fromId), routes.ApplicationController.show(application.id))
                                     </div>
                                 }
                                 @helper.CSRF.formField

--- a/conf/routes
+++ b/conf/routes
@@ -77,7 +77,6 @@ POST    /newsletter                      controllers.UserController.subscribeNew
 GET     /territoires                            controllers.AreaController.all
 GET     /territoires/deploiement                controllers.AreaController.deploymentDashboard
 GET     /territoires/deploiement/france-service controllers.AreaController.franceServiceDeploymentDashboard
-GET     /territoires/:areaId                    controllers.AreaController.change(areaId: java.util.UUID)
 GET     /territoires/:areaId/demandes           controllers.ApplicationController.all(areaId: java.util.UUID)
 GET     /territoires/:areaId/demandes.csv       controllers.ApplicationController.allCSV(areaId: java.util.UUID)
 GET     /territoires/:areaId/utilisateurs       controllers.UserController.all(areaId: java.util.UUID)


### PR DESCRIPTION
* les aidants peuvent inviter des opérateurs dans le territoire de la demande
* résout le problème des transferts de demandes dans d’autres territoires
* supprime areaId dans la session