### PR TITLE
Ajoute les utilisateurs sans groupe dans les interfaces d'admin

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -518,7 +518,7 @@ case class ApplicationController @Inject() (
 
     val (usersFuture, applicationsFutureNoDateFilter, groupsFuture) =
       if (areaIds.isEmpty && organisationIds.isEmpty && groupIds.isEmpty) {
-        (userService.all, applicationService.all, userGroupService.all)
+        (userService.allNoNameNoEmail, applicationService.all, userGroupService.all)
       } else if (areaIds.nonEmpty && groupIds.isEmpty) {
         val groupsFuture = userGroupService.byAreas(areaIds)
         if (organisationIds.isEmpty) {

--- a/app/controllers/AreaController.scala
+++ b/app/controllers/AreaController.scala
@@ -108,7 +108,7 @@ case class AreaController @Inject() (
       DeploymentDashboardUnauthorized -> "Accès non autorisé au dashboard de déploiement"
     } { () =>
       val userGroups = userGroupService.allGroups
-      userService.all.map { users =>
+      userService.allNoNameNoEmail.map { users =>
         def usersIn(area: Area, organisationSet: Set[Organisation]): List[User] =
           for {
             group <- userGroups.filter(group =>

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -101,7 +101,12 @@ case class UserController @Inject() (
             }
           )
         val usersFuture: Future[List[User]] =
-          groupsFuture.map(groups => userService.byGroupIds(groups.map(_.id)))
+          if (Authorization.isAdmin(request.rights) && areaId == Area.allArea.id) {
+            // Includes users without any group for debug purpose
+            userService.all
+          } else {
+            groupsFuture.map(groups => userService.byGroupIds(groups.map(_.id)))
+          }
         val applications = applicationService.allByArea(selectedArea.id, anonymous = true)
 
         eventService.log(UsersShowed, "Visualise la vue des utilisateurs")

--- a/app/controllers/UserController.scala
+++ b/app/controllers/UserController.scala
@@ -134,8 +134,13 @@ case class UserController @Inject() (
       } { () =>
         val area = Area.fromId(areaId).get
         val usersFuture: Future[List[User]] = if (areaId == Area.allArea.id) {
-          groupService.byAreas(request.currentUser.areas).map { groupsOfArea =>
-            userService.byGroupIds(groupsOfArea.map(_.id))
+          if (Authorization.isAdmin(request.rights)) {
+            // Includes users without any group for debug purpose
+            userService.all
+          } else {
+            groupService.byAreas(request.currentUser.areas).map { groupsOfArea =>
+              userService.byGroupIds(groupsOfArea.map(_.id))
+            }
           }
         } else {
           groupService.byArea(areaId).map { groupsOfArea =>


### PR DESCRIPTION
* J'ai renommé `UserService.all` => `UserService.allNoNameNoEmail`.
* Créé une autre méthode `UserService.all`
* Supprimé les noms des utilisateurs dans les stats (l'utilité de la méthode n'était pas claire)