### PR TITLE
Interdit la mise à jour des flags expert et admin via le formulaire utilisateur

### DIFF
--- a/app/services/UserService.scala
+++ b/app/services/UserService.scala
@@ -175,28 +175,27 @@ class UserService @Inject() (
         Left(errorMessage)
     }
 
-  def update(user: User) = db.withConnection { implicit connection =>
-    val observableOrganisationIds = user.observableOrganisationIds.map(_.id)
-    SQL"""
+  def update(user: User): Future[Boolean] =
+    Future(db.withConnection { implicit connection =>
+      val observableOrganisationIds = user.observableOrganisationIds.map(_.id)
+      SQL"""
           UPDATE "user" SET
           name = ${user.name},
           qualite = ${user.qualite},
           email = ${user.email},
           helper = ${user.helper},
           instructor = ${user.instructor},
-          admin = ${user.admin},
           areas = array[${user.areas.distinct}]::uuid[],
           commune_code = ${user.communeCode},
           group_admin = ${user.groupAdmin},
           group_ids = array[${user.groupIds.distinct}]::uuid[],
-          expert = ${user.expert},
           phone_number = ${user.phoneNumber},
           disabled = ${user.disabled},
           observable_organisation_ids = array[${observableOrganisationIds.distinct}]::varchar[],
           shared_account = ${user.sharedAccount}
           WHERE id = ${user.id}::uuid
        """.executeUpdate() == 1
-  }
+    })
 
   def acceptCGU(userId: UUID, acceptNewsletter: Boolean) = db.withConnection {
     implicit connection =>

--- a/app/views/editUser.scala.html
+++ b/app/views/editUser.scala.html
@@ -109,13 +109,6 @@
       <br>
     }
     <br>
-    <b style="color: red">@helper.checkbox(form("admin"), List[Option[(Symbol, String)]](
-        Some("type" -> "checkbox"),
-        Some("label" -> "Admin de la zone"),
-        Some("class" -> "mdl-checkbox__input"),
-        if (canEditUser) None else Some("disabled" -> "")
-      ).flatten:_*)
-    </b>
   </div>
   <div class="mdl-grid mdl-cell--6-col-desktop mdl-cell--12-col">
       <div class="mdl-cell mdl-cell--12-col-desktop mdl-cell--12-col">


### PR DESCRIPTION
Passe `UserService.update` en non-bloquant.