### PR TITLE
Revert sentry version (doesn't work in prod)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ libraryDependencies ++= Seq(
   "org.webjars.npm" % "xlsx" % "0.16.7"
 )
 // Crash
-libraryDependencies += "io.sentry" % "sentry-logback" % "3.1.1"
+libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.30"
 
 // Adds additional packages into Twirl
 TwirlKeys.templateImports += "constants.Constants"


### PR DESCRIPTION
Ça ne marche pas en prod, il n'y a plus de sentry depuis 10 jours.
Note : 
- Vérifier que les changements de version majeur ne pose pas de problème en prod