### PR TITLE
Correction du build pour IE11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ libraryDependencies ++= Seq(
   ehcache
 )
 
-pipelineStages := Seq(rjs, digest, gzip)
+pipelineStages := Seq(digest, gzip)
 
 libraryDependencies += specs2 % Test
 libraryDependencies += guice

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.3")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "3.0.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 


### PR DESCRIPTION
Suppression de rjs, enlève les erreur bloquantes. A noter qu'il reste des erreurs de polyfills manquants, mais ça ne bloque pas les utilisateurs.

IE11 marche sur windows 7 avec ce fix (formulaire d'inscription CGU + faire des demandes) :
<img width="966" alt="Screen Shot 2020-10-27 at 18 39 29" src="https://user-images.githubusercontent.com/4394842/97340289-e2377600-1883-11eb-8d3f-6355137ee8b4.png">

Différence de quelques ko sur le JS legacy :
(avant / prod)
<img width="1713" alt="Screen Shot 2020-10-27 at 18 22 33" src="https://user-images.githubusercontent.com/4394842/97340660-5eca5480-1884-11eb-96b5-48d740fbda81.png">

(après / review app)
<img width="1706" alt="Screen Shot 2020-10-27 at 18 32 29" src="https://user-images.githubusercontent.com/4394842/97340727-70136100-1884-11eb-979b-3dfed6763771.png">
