### PR TITLE
Pas d'update de sentry-logback par scala-steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "io.sentry", artifactId = "sentry-logback" } ]


### PR DESCRIPTION
Pour éviter https://github.com/betagouv/aplus/pull/832