### PR TITLE
Change la couleur grise du texte pour l'accessibilité (point design)

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -843,3 +843,7 @@ Tabs
     background: red;
     color: white;
 }
+
+.mdl-card__supporting-text {
+    color: rgba(0, 0, 0, 0.70);
+}


### PR DESCRIPTION
**Avant :**
<img width="859" alt="Capture d’écran 2020-11-25 à 14 16 41" src="https://user-images.githubusercontent.com/1923376/100232643-e8734d80-2f28-11eb-8c63-b945ee9cfd6a.png">


**Après :**
<img width="865" alt="Capture d’écran 2020-11-25 à 14 16 18" src="https://user-images.githubusercontent.com/1923376/100232654-ec06d480-2f28-11eb-9074-fb9287e0aaab.png">
