### PR TITLE
Distinguer les demandes encore non visualisées

### DIFF
--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -2,6 +2,8 @@ package models
 
 import cats.syntax.all._
 import cats.{Eq, Show}
+import helper.BooleanHelper
+import helper.BooleanHelper.not
 import models.Answer.AnswerType.ApplicationProcessed
 import models.Application.SeenByUser
 import models.Application.Status.{Archived, New, Processed, Processing, Sent, ToArchive}
@@ -73,10 +75,11 @@ case class Application(
     s"$areaName $creatorName $userInfosStripped $subjectStripped $descriptionStripped $invitedUserNames $answersStripped"
   }
 
-  def hasBeenDisplayedFor(user: User) = seenByUserIds.contains[UUID](user.id)
-
   private def isProcessed = answers.lastOption.exists(_.answerType === ApplicationProcessed)
   private def isCreator(user: User) = user.id === creatorUserId
+
+  def hasBeenDisplayedFor(user: User) =
+    not(isCreator(user)) && seenByUserIds.contains[UUID](user.id)
 
   def longStatus(user: User): Application.Status = {
     def answeredByOtherThan(user: User) = answers.exists(_.creatorUserID =!= user.id)

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -78,7 +78,7 @@ case class Application(
   private def isCreator(user: User) = user.id === creatorUserId
 
   def hasBeenDisplayedFor(user: User) =
-    not(isCreator(user)) && seenByUserIds.contains[UUID](user.id)
+    isCreator(user) || seenByUserIds.contains[UUID](user.id)
 
   def longStatus(user: User): Application.Status = {
     def answeredByOtherThan(user: User) = answers.exists(_.creatorUserID =!= user.id)

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -74,10 +74,10 @@ case class Application(
   }
 
   private def isProcessed = answers.lastOption.exists(_.answerType === ApplicationProcessed)
-  private def isCreator(user: User) = user.id === creatorUserId
+  private def isCreator(userId: UUID) = userId === creatorUserId
 
-  def hasBeenDisplayedFor(user: User) =
-    isCreator(user) || seenByUserIds.contains[UUID](user.id)
+  def hasBeenDisplayedFor(userId: UUID) =
+    isCreator(userId) || seenByUserIds.contains[UUID](userId)
 
   def longStatus(user: User): Application.Status = {
     def answeredByOtherThan(user: User) = answers.exists(_.creatorUserID =!= user.id)
@@ -85,10 +85,10 @@ case class Application(
 
     closed match {
       case true                                                   => Archived
-      case false if isProcessed && isCreator(user)                => ToArchive
+      case false if isProcessed && isCreator(user.id)             => ToArchive
       case false if isProcessed                                   => Processed
       case false if answeredByOtherThan(user) | seenByInvitedUser => Processing
-      case false if isCreator(user)                               => Sent
+      case false if isCreator(user.id)                            => Sent
       case false                                                  => New
     }
   }

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -2,7 +2,6 @@ package models
 
 import cats.syntax.all._
 import cats.{Eq, Show}
-import helper.BooleanHelper.not
 import models.Answer.AnswerType.ApplicationProcessed
 import models.Application.SeenByUser
 import models.Application.Status.{Archived, New, Processed, Processing, Sent, ToArchive}

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -2,7 +2,6 @@ package models
 
 import cats.syntax.all._
 import cats.{Eq, Show}
-import helper.BooleanHelper
 import helper.BooleanHelper.not
 import models.Answer.AnswerType.ApplicationProcessed
 import models.Application.SeenByUser

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -87,8 +87,6 @@ case class Application(
       case false if answeredByOtherThan(user) | seenByInvitedUser => Processing
       case false if isCreator(user)                               => Sent
       case false                                                  => New
-      // FIXME Avis de consultation ?
-      // FIXME Idée : Trouver un autre signe pour montrer que j'ai vu la demande (gras pour les non lues ? code couleur ?)
     }
   }
 

--- a/app/models/Application.scala
+++ b/app/models/Application.scala
@@ -73,6 +73,8 @@ case class Application(
     s"$areaName $creatorName $userInfosStripped $subjectStripped $descriptionStripped $invitedUserNames $answersStripped"
   }
 
+  def hasBeenDisplayedFor(user: User) = seenByUserIds.contains[UUID](user.id)
+
   private def isProcessed = answers.lastOption.exists(_.answerType === ApplicationProcessed)
   private def isCreator(user: User) = user.id === creatorUserId
 

--- a/app/views/myApplications.scala.html
+++ b/app/views/myApplications.scala.html
@@ -16,7 +16,7 @@
             </tfoot>
             <tbody>
             @for((application) <- applications.sortBy(_.closed)) {
-                <tr onclick="window.document.location = '@routes.ApplicationController.show(application.id)';" data-search="@application.searchData" class="searchable-row @if(application.longStatus(user) === New) {td--important-border} else {td--clear-border}">
+                <tr onclick="window.document.location = '@routes.ApplicationController.show(application.id)';" data-search="@application.searchData" class="searchable-row @if(application.longStatus(user) === New) {td--important-border} else {td--clear-border} @if(!application.hasBeenDisplayedFor(user)) {td--blue-background}">
                   <td class="mdl-data-table__cell--non-numeric mdl-data-table__cell--content-size">
                     @toHtml(views.helpers.applications.statusTag(application, user))
                     @if(Authorization.isAdmin(currentUserRights)) {

--- a/app/views/myApplications.scala.html
+++ b/app/views/myApplications.scala.html
@@ -16,7 +16,7 @@
             </tfoot>
             <tbody>
             @for((application) <- applications.sortBy(_.closed)) {
-                <tr onclick="window.document.location = '@routes.ApplicationController.show(application.id)';" data-search="@application.searchData" class="searchable-row @if(application.longStatus(user) === New) {td--important-border} else {td--clear-border} @if(!application.hasBeenDisplayedFor(user)) {td--blue-background}">
+                <tr onclick="window.document.location = '@routes.ApplicationController.show(application.id)';" data-search="@application.searchData" class="searchable-row @if(application.longStatus(user) === New) {td--important-border} else {td--clear-border} @if(!application.hasBeenDisplayedFor(user.id)) {td--blue-background}">
                   <td class="mdl-data-table__cell--non-numeric mdl-data-table__cell--content-size">
                     @toHtml(views.helpers.applications.statusTag(application, user))
                     @if(Authorization.isAdmin(currentUserRights)) {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -274,6 +274,10 @@ html, body {
     border-color: #666666;
 }
 
+.td--blue-background {
+    background-color: #f1f6fc;
+}
+
 .icon--light {
     color: #D8D8D8;
 }

--- a/test/models/ApplicationSpec.scala
+++ b/test/models/ApplicationSpec.scala
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 
-import java.time.{ZoneId, ZonedDateTime}
+import java.time.{Instant, ZoneId, ZonedDateTime}
 import java.util.UUID
 
 @RunWith(classOf[JUnitRunner])
@@ -259,7 +259,73 @@ class ApplicationSpec extends Specification {
 
       application.status must equalTo(New)
     }
+  }
 
+  "Application displaying should be" >> {
+    "false for an application creator" >> {
+      val userId = UUID.randomUUID()
+      val application = Application(
+        id = UUID.randomUUID(),
+        creationDate = ZonedDateTime.now(),
+        creatorUserName = "Mathieu",
+        creatorUserId = userId,
+        subject = "Sujet",
+        description = "Description",
+        userInfos = Map.empty[String, String],
+        invitedUsers = Map.empty[UUID, String],
+        area = UUID.randomUUID(),
+        irrelevant = false,
+        mandatType = Option.empty[MandatType],
+        mandatDate = Option.empty[String],
+        invitedGroupIdsAtCreation = List.empty[UUID]
+      )
+
+      application.hasBeenDisplayedFor(userId) must beTrue
+    }
+
+    "false for an application with the userId in seenByUsers" >> {
+      val userId = UUID.randomUUID()
+      val application = Application(
+        id = UUID.randomUUID(),
+        creationDate = ZonedDateTime.now(),
+        creatorUserName = "Mathieu",
+        creatorUserId = UUID.randomUUID(),
+        subject = "Sujet",
+        description = "Description",
+        userInfos = Map.empty[String, String],
+        invitedUsers = Map.empty[UUID, String],
+        seenByUsers = List(SeenByUser(userId = userId, lastSeenDate = Instant.now())),
+        area = UUID.randomUUID(),
+        irrelevant = false,
+        mandatType = Option.empty[MandatType],
+        mandatDate = Option.empty[String],
+        invitedGroupIdsAtCreation = List.empty[UUID]
+      )
+
+      application.hasBeenDisplayedFor(userId) must beTrue
+    }
+
+    "true for an application without the userId in seenByUsers" >> {
+      val userId = UUID.randomUUID()
+      val application = Application(
+        id = UUID.randomUUID(),
+        creationDate = ZonedDateTime.now(),
+        creatorUserName = "Mathieu",
+        creatorUserId = UUID.randomUUID(),
+        subject = "Sujet",
+        description = "Description",
+        userInfos = Map.empty[String, String],
+        invitedUsers = Map.empty[UUID, String],
+        seenByUsers = List.empty[SeenByUser],
+        area = UUID.randomUUID(),
+        irrelevant = false,
+        mandatType = Option.empty[MandatType],
+        mandatDate = Option.empty[String],
+        invitedGroupIdsAtCreation = List.empty[UUID]
+      )
+
+      application.hasBeenDisplayedFor(userId) must beFalse
+    }
   }
 
 }


### PR DESCRIPTION
Afficher les demandes non visualisées en bleu (à la Frontapp)

<img width="941" alt="Capture d’écran 2020-12-04 à 16 27 45" src="https://user-images.githubusercontent.com/1923376/101182009-dc387000-364d-11eb-8070-8bf2cf9988d3.png">
