### PR TITLE
Corrige la petite bande sous le footer

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -112,7 +112,7 @@
             </div>
 
             <main class="mdl-layout__content mdl-color--grey-200">
-                <div class="mdl-grid main__grid single--align-content-flex-start @if(maxWidth) { single--max-width-960px }" >
+                <div class="mdl-grid main__grid single--align-content-flex-start mdl-mega-footer-fix @if(maxWidth) { single--max-width-960px }" >
 
                 @flash.get("error").map { error =>
                     <div class="mdl-cell mdl-cell--12-col" id="answer-error">
@@ -138,7 +138,7 @@
 
                     @content
                 </div>
-                <footer class="mdl-mega-footer mdl-mega-footer-fix do-not-print">
+                <footer class="mdl-mega-footer do-not-print">
                     <div class="mdl-mega-footer--bottom-section">
                         <div class="mdl-logo">
                             Administration+ @java.time.LocalDate.now().getYear() :

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -121,11 +121,9 @@ html, body {
     z-index: 10;
 }
 
-/* Note: the mdl footer has too much padding at the bottom and demands a
- * mandatory scroll
- */
+/* Note: the mdl footer is off by a band of unused 4px */
 .mdl-mega-footer-fix {
-    padding-bottom: 4px;
+    margin-bottom: 4px;
 }
 
 .mdl-card__supporting-text {


### PR DESCRIPTION
Actuellement ça marche sur Chrome mais pas Firefox (ce fix ne marche pas sur Chrome)

Firefox avant :
<img width="577" alt="Screen Shot 2021-01-20 at 16 59 09" src="https://user-images.githubusercontent.com/4394842/105207093-6168dd00-5b47-11eb-9ed3-3a39149856f2.png">
