### PR TITLE
Ajoute un champ description détaillée pour les groupes

### DIFF
--- a/app/controllers/CSVImportController.scala
+++ b/app/controllers/CSVImportController.scala
@@ -135,7 +135,8 @@ case class CSVImportController @Inject() (
           creationDate = Time.nowParis(),
           areaIds = group.group.areaIds,
           organisation = group.group.organisation,
-          email = group.group.email
+          email = group.group.email,
+          publicNote = None
         ),
         users = group.users.map(user =>
           CSVUserFormData(
@@ -194,7 +195,8 @@ case class CSVImportController @Inject() (
         "Vous devez sélectionner une organisation dans la liste",
         _.exists(Organisation.isValidId)
       ),
-      "email" -> optional(email)
+      "email" -> optional(email),
+      "publicNote" -> ignored(Option.empty[String])
     )(UserGroup.apply)(UserGroup.unapply)
 
   private def importUsersAfterReviewForm(date: ZonedDateTime): Form[List[CSVUserGroupFormData]] =

--- a/app/controllers/GroupController.scala
+++ b/app/controllers/GroupController.scala
@@ -16,6 +16,7 @@ import play.libs.ws.WSClient
 import services._
 import helper.BooleanHelper.not
 import helper.Time
+import helper.StringHelper.commonStringInputNormalization
 import models.EventType.{
   AddGroupUnauthorized,
   AddUserGroupError,
@@ -208,8 +209,12 @@ case class GroupController @Inject() (
     Form(
       mapping(
         "id" -> ignored(UUID.randomUUID()),
-        "name" -> text(maxLength = 60),
-        "description" -> optional(text),
+        "name" -> text(maxLength = 60)
+          .transform[String](commonStringInputNormalization, commonStringInputNormalization),
+        "description" -> optional(text).transform[Option[String]](
+          _.map(commonStringInputNormalization).filter(_.nonEmpty),
+          _.map(commonStringInputNormalization).filter(_.nonEmpty)
+        ),
         "insee-code" -> list(text),
         "creationDate" -> ignored(ZonedDateTime.now(timeZone)),
         "area-ids" -> list(uuid)
@@ -219,7 +224,11 @@ case class GroupController @Inject() (
           )
           .verifying("Vous devez sélectionner au moins 1 territoire", _.nonEmpty),
         "organisation" -> optional(of[Organisation.Id]),
-        "email" -> optional(email)
+        "email" -> optional(email),
+        "publicNote" -> optional(text).transform[Option[String]](
+          _.map(commonStringInputNormalization).filter(_.nonEmpty),
+          _.map(commonStringInputNormalization).filter(_.nonEmpty)
+        )
       )(UserGroup.apply)(UserGroup.unapply)
     )
 

--- a/app/helper/MiscHelpers.scala
+++ b/app/helper/MiscHelpers.scala
@@ -1,0 +1,19 @@
+package helper
+
+object MiscHelpers {
+
+  // https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Foldable.scala#L775
+  def intersperseList[A](xs: List[A], x: A): List[A] = {
+    val bld = List.newBuilder[A]
+    val it = xs.iterator
+    if (it.hasNext) {
+      bld += it.next()
+      while (it.hasNext) {
+        bld += x
+        bld += it.next()
+      }
+    }
+    bld.result()
+  }
+
+}

--- a/app/helper/TwirlImports.scala
+++ b/app/helper/TwirlImports.scala
@@ -2,7 +2,7 @@ package helper
 
 import play.twirl.api.Html
 import scala.language.implicitConversions
-import scalatags.Text.all.Frag
+import scalatags.Text.all.{frag, Frag, SeqFrag, Tag}
 
 object TwirlImports {
 
@@ -13,5 +13,7 @@ object TwirlImports {
     (Symbol(couple._1), couple._2)
 
   implicit def toHtml(frag: Frag): Html = Html(frag.render)
+
+  implicit def toHtml(tags: List[Tag]): Html = toHtml(frag(tags))
 
 }

--- a/app/models/UserGroup.scala
+++ b/app/models/UserGroup.scala
@@ -13,7 +13,9 @@ case class UserGroup(
     creationDate: ZonedDateTime,
     areaIds: List[UUID],
     organisation: Option[Organisation.Id] = None,
-    email: Option[String] = None
+    email: Option[String] = None,
+    // This is a note displayed to users trying to select this group
+    publicNote: Option[String]
 ) {
 
   def canHaveUsersAddedBy(user: User): Boolean =
@@ -31,6 +33,7 @@ case class UserGroup(
   lazy val emailLog: String = email.map(withQuotes).getOrElse("<vide>")
   lazy val organisationLog: String = organisation.map(_.id).getOrElse("<vide>")
   lazy val areaIdsLog: String = areaIds.mkString(", ")
+  lazy val publicNoteLog: String = publicNote.map(withQuotes).getOrElse("<vide>")
 
   lazy val toLogString: String =
     "[" + List[(String, String)](
@@ -39,7 +42,8 @@ case class UserGroup(
       ("Description", descriptionLog),
       ("BAL", emailLog),
       ("Organisme", organisationLog),
-      ("Territoires", areaIdsLog)
+      ("Territoires", areaIdsLog),
+      ("Notice", publicNoteLog)
     ).map { case (fieldName, value) => s"$fieldName : $value" }.mkString(" | ") + "]"
 
   def toDiffLogString(other: UserGroup): String = {
@@ -50,6 +54,7 @@ case class UserGroup(
       ("BAL", email =!= other.email, emailLog, other.emailLog),
       ("Organisme", organisation =!= other.organisation, organisationLog, other.organisationLog),
       ("Territoires", areaIds =!= other.areaIds, areaIdsLog, other.areaIdsLog),
+      ("Notice", publicNote =!= other.publicNote, publicNoteLog, other.publicNoteLog),
     ).collect { case (name, true, thisValue, thatValue) => s"$name : $thisValue -> $thatValue" }
     "[" + diffs.mkString(" | ") + "]"
   }

--- a/app/services/UserGroupService.scala
+++ b/app/services/UserGroupService.scala
@@ -31,7 +31,8 @@ class UserGroupService @Inject() (
       "creation_date",
       "area_ids",
       "organisation",
-      "email"
+      "email",
+      "public_note"
     )
     .map(a => a.copy(creationDate = a.creationDate.withZoneSameInstant(Time.timeZoneParis)))
 
@@ -79,7 +80,8 @@ class UserGroupService @Inject() (
           description = ${group.description},
           organisation = ${group.organisation.map(_.id)},
           area_ids = array[${group.areaIds}]::uuid[],
-          email = ${group.email}
+          email = ${group.email},
+          public_note = ${group.publicNote}
           WHERE id = ${group.id}::uuid
        """.executeUpdate() === 1
     //TODO: insee_code = array[${group.inseeCode}]::character varying(5)[], have been remove temporary

--- a/app/views/createApplication.scala.html
+++ b/app/views/createApplication.scala.html
@@ -74,65 +74,7 @@
                             }
                         </div>
 
-                    <div class="mdl-grid" style="background-color: white;">
-                        @if(applicationForm("groups").hasErrors) {
-                            <p style="color: red; font-weight: bold;">@applicationForm("groups").errors.map(_.format).mkString(", ")</p>
-                        }
-
-                        <fieldset class="single--margin-left-8px single--margin-right-24px single--margin-top-8px mdl-cell mdl-cell--12-col">
-                          @for(group <- organisationGroups.sortBy(_.name)) {
-                            @defining(group.organisationSetOrDeducted) { organisation: Option[Organisation] =>
-                            <div class="single--padding-top-8px single--padding-bottom-16px single--padding-left-16px">
-                              <label for="invite-@group.id"
-                                     class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
-                                <input id="invite-@group.id"
-                                       class="mdl-checkbox__input application-form-invited-groups-checkbox"
-                                       type="checkbox"
-                                       name="groups[]"
-                                       value="@group.id"
-                                       data-group-name="@group.name"
-                                       @if(applicationForm.data.find({case (k, v) => k.startsWith("groups[") && v === group.id.toString})){ checked="checked" }
-                                >
-                                <span class="mdl-checkbox__label">
-                                  <b>@group.name</b>
-                                  @if(organisation.nonEmpty){ <em>(@organisation.get.name)</em> }
-                                </span>
-                              </label>
-
-                              <div id="invite-@group.id-additional-infos" class="organisation-row @if(!applicationForm.data.find({case (k, v) => k.startsWith("groups[") && v === group.id.toString})){ invisible }">
-                                @if(organisation.map(_.id).filter(_ === Organisation.cafId).nonEmpty) {
-                                  <tr>
-                                    <td style="text-align: left; white-space: normal">
-                                      <div class="info-box info-box--no-spacing">
-                                        La CAF aura besoin du <b>numéro identifiant CAF</b> et à défaut de la date de naissance. Vous pouvez le renseigner dans <b>Informations concernant l'usager</b> ci-dessous.
-                                      </div>
-                                    </td>
-                                  </tr>
-                                } else if (organisation.map(_.id).filter(_ === Organisation.cpamId).nonEmpty) {
-                                  <tr>
-                                    <td style="text-align: left; white-space: normal">
-                                      <div class="info-box info-box--no-spacing">
-                                        La CPAM aura besoin du <b>numéro de sécurité sociale</b> et à défaut de la date de naissance. Vous pouvez le renseigner dans <b>Informations concernant l'usager</b> ci-dessous.
-                                      </div>
-                                    </td>
-                                  </tr>
-                                } else if (organisation.find(entity => Set(Organisation.prefId, Organisation.sousPrefId).contains(entity.id)).nonEmpty)  {
-                                  <tr>
-                                    <td style="text-align: left; white-space: normal">
-                                      <div class="info-box info-box--no-spacing">
-                                        La préfecture (ou sous-préfecture) ne répondra pas forcément aux questions relative aux renouvellements de titre de séjour ou des certificats d’immatriculation. Pour les titres de séjour concernant les étudiants, vous pouvez utiliser la plateforme du ministère de l’intérieur <a href="https://administration-etrangers-en-france.interieur.gouv.fr/particuliers/#/" target="_blank" rel="noopener">à cette adresse</a>. Pour les certificats d’immatriculation, vous pouvez contacter l’ANTS <a href="https://ants.gouv.fr/Contacter-l-ANTS/Contactez-nous" target="_blank" rel="noopener">à cette adresse</a>.
-                                      </div>
-                                    </td>
-                                  </tr>
-                                }
-                              </div>
-
-                            </div>
-                            }
-                            }
-                        </fieldset>
-
-                    </div>
+                        @toHtml(views.helpers.applications.applicationTargetGroups(organisationGroups, applicationForm.data, applicationForm("groups").hasErrors, applicationForm("groups").errors))
 
 
                     <br>

--- a/app/views/editGroup.scala.html
+++ b/app/views/editGroup.scala.html
@@ -17,8 +17,16 @@
             </div>
             <div class="mdl-cell mdl-cell--12-col  mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
                 <input class="mdl-textfield__input" type="text" id="description" name="description" value="@userGroup.description" @if(!currentUser.admin) { disabled }>
-                <label class="mdl-textfield__label" for="description">Description du groupe</label>
+                <label class="mdl-textfield__label" for="description">Description succincte</label>
             </div>
+
+            <div class="mdl-cell mdl-cell--12-col  mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+              <textarea class="mdl-textfield__input single--height-auto" type="text" rows="3" id="publicNote" name="publicNote">@userGroup.publicNote</textarea>
+                <label class="mdl-textfield__label" for="publicNote">Description détaillée</label>
+            </div>
+
+            @toHtml(views.helpers.applications.groupFormExample(userGroup))
+
             @if(userGroup.inseeCode.nonEmpty) {
                 <div class="mdl-cell mdl-cell--12-col">
                     <b>Code INSEE</b> (non utilisé pour le moment) : @userGroup.inseeCode.mkString(", ")

--- a/app/views/helpers/applications.scala
+++ b/app/views/helpers/applications.scala
@@ -1,8 +1,11 @@
 package views.helpers
 
 import cats.syntax.all._
+import helper.MiscHelpers.intersperseList
 import models.Application.Status.{Archived, New, Processed, Processing, Sent, ToArchive}
-import models.{Application, User}
+import models.{Application, Organisation, User, UserGroup}
+import play.api.data.FormError
+import play.api.i18n.Messages
 import scalatags.Text.all._
 
 object applications {
@@ -26,5 +29,176 @@ object applications {
       status.show
     )
   }
+
+  /** This is for the Application creation form
+    * Some fields here are from `Form`
+    * https://www.playframework.com/documentation/2.8.x/api/scala/play/api/data/Form.html
+    */
+  def applicationTargetGroups(
+      groups: List[UserGroup],
+      formData: Map[String, String],
+      formHasErrors: Boolean,
+      formErrors: Seq[FormError]
+  )(implicit messagesProvider: Messages): Tag =
+    div(
+      cls := "mdl-grid single--background-color-white",
+      if (formHasErrors)
+        p(
+          cls := "global-errors",
+          formErrors.map(_.format).mkString(", ")
+        )
+      else
+        (),
+      fieldset(
+        cls := "single--margin-left-8px single--margin-right-24px single--margin-top-8px mdl-cell mdl-cell--12-col",
+        groupCheckboxes(groups, formData)
+      )
+    )
+
+  /** On the application view */
+  def inviteTargetGroups(groups: List[UserGroup]): Tag =
+    fieldset(
+      cls := "single--margin-top-16px mdl-cell mdl-cell--12-col",
+      legend(
+        cls := "single--padding-top-16px single--padding-bottom-16px mdl-typography--title",
+        "Inviter un organisme sur la discussion"
+      ),
+      groupCheckboxes(groups, Map.empty)
+    )
+
+  /** On the Group Form */
+  def groupFormExample(group: UserGroup): Tag =
+    div(
+      cls := "single--margin-left-8px",
+      div(
+        cls := "single--margin-bottom-8px single--font-size-16px",
+        "La ",
+        b("description succincte"),
+        " et la ",
+        b("description détaillée"),
+        " permettent d’orienter l’utilisateur souhaitant créer une demande. Ils lui sont affichés de la façon suivante :"
+      ),
+      div(
+        cls := "mdl-grid single--background-color-white form-example",
+        fieldset(
+          cls := "single--margin-left-8px single--margin-right-24px single--margin-top-8px mdl-cell mdl-cell--12-col",
+          groupCheckboxes(group :: Nil, Map("groups[]" -> group.id.toString))
+        )
+      )
+    )
+
+  /** Restriction: to work with the JS part, it must be unique per page */
+  def groupCheckboxes(groups: List[UserGroup], formData: Map[String, String]): List[Tag] =
+    groups.sortBy(_.name).map { group =>
+      val organisation: Option[Organisation] = group.organisationSetOrDeducted
+      val groupIsChecked =
+        formData.exists({ case (k, v) => k.startsWith("groups[") && v === group.id.toString })
+
+      def publicNoteBox(inner: Frag) =
+        tr(
+          td(
+            cls := "info-box-container",
+            div(
+              cls := "info-box info-box--no-spacing",
+              inner
+            )
+          )
+        )
+      val publicNote: Frag =
+        group.publicNote match {
+          case Some(publicNote) =>
+            publicNoteBox(
+              frag(intersperseList(publicNote.split("\n").toList.map(s => frag(s)), br))
+            )
+          case None =>
+            if (organisation.map(_.id).filter(_ === Organisation.cafId).nonEmpty) {
+              publicNoteBox(
+                frag(
+                  "La CAF aura besoin du ",
+                  b("numéro identifiant CAF"),
+                  " et à défaut de la date de naissance. ",
+                  "Vous pouvez le renseigner dans ",
+                  b("Informations concernant l’usager"),
+                  " ci-dessous."
+                )
+              )
+            } else if (organisation.map(_.id).filter(_ === Organisation.cpamId).nonEmpty) {
+              tr(
+                td(
+                  cls := "info-box-container",
+                  div(
+                    cls := "info-box info-box--no-spacing",
+                    "La CPAM aura besoin du ",
+                    b("numéro de sécurité sociale"),
+                    " et à défaut de la date de naissance. ",
+                    "Vous pouvez le renseigner dans ",
+                    b("Informations concernant l’usager"),
+                    " ci-dessous."
+                  )
+                )
+              )
+            } else if (
+              organisation
+                .find(entity =>
+                  Set(Organisation.prefId, Organisation.sousPrefId).contains(entity.id)
+                )
+                .nonEmpty
+            ) {
+              tr(
+                td(
+                  cls := "info-box-container",
+                  div(
+                    cls := "info-box info-box--no-spacing",
+                    "La préfecture (ou sous-préfecture) ne répondra pas forcément aux questions relative aux renouvellements de titre de séjour ou des certificats d’immatriculation. Pour les titres de séjour concernant les étudiants, vous pouvez utiliser la plateforme du ministère de l’intérieur ",
+                    a(
+                      href := "https://administration-etrangers-en-france.interieur.gouv.fr/particuliers/#/",
+                      target := "_blank",
+                      rel := "noopener",
+                      "à cette adresse"
+                    ),
+                    ". Pour les certificats d’immatriculation, vous pouvez contacter l’ANTS ",
+                    a(
+                      href := "https://ants.gouv.fr/Contacter-l-ANTS/Contactez-nous",
+                      target := "_blank",
+                      rel := "noopener",
+                      "à cette adresse"
+                    ),
+                    "."
+                  )
+                )
+              )
+            } else ()
+        }
+
+      div(
+        cls := "single--padding-top-8px single--padding-bottom-16px single--padding-left-16px",
+        label(
+          `for` := s"invite-${group.id}",
+          cls := "mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect single--height-auto",
+          input(
+            id := s"invite-${group.id}",
+            cls := "mdl-checkbox__input application-form-invited-groups-checkbox",
+            `type` := "checkbox",
+            name := "groups[]",
+            value := s"${group.id}",
+            attr("data-group-name") := s"${group.name}",
+            if (groupIsChecked) checked := "checked"
+            else ()
+          ),
+          span(
+            cls := "mdl-checkbox__label",
+            b(group.name),
+            organisation.map(org => em(s" (${org.name})"))
+          ),
+          br,
+          span(group.description)
+        ),
+        div(
+          id := s"invite-${group.id}-additional-infos",
+          cls := (if (groupIsChecked) "organisation-row" else "organisation-row invisible"),
+          publicNote
+        )
+      )
+    }
 
 }

--- a/app/views/helpers/applications.scala
+++ b/app/views/helpers/applications.scala
@@ -123,18 +123,14 @@ object applications {
                 )
               )
             } else if (organisation.map(_.id).filter(_ === Organisation.cpamId).nonEmpty) {
-              tr(
-                td(
-                  cls := "info-box-container",
-                  div(
-                    cls := "info-box info-box--no-spacing",
-                    "La CPAM aura besoin du ",
-                    b("numéro de sécurité sociale"),
-                    " et à défaut de la date de naissance. ",
-                    "Vous pouvez le renseigner dans ",
-                    b("Informations concernant l’usager"),
-                    " ci-dessous."
-                  )
+              publicNoteBox(
+                frag(
+                  "La CPAM aura besoin du ",
+                  b("numéro de sécurité sociale"),
+                  " et à défaut de la date de naissance. ",
+                  "Vous pouvez le renseigner dans ",
+                  b("Informations concernant l’usager"),
+                  " ci-dessous."
                 )
               )
             } else if (
@@ -144,27 +140,23 @@ object applications {
                 )
                 .nonEmpty
             ) {
-              tr(
-                td(
-                  cls := "info-box-container",
-                  div(
-                    cls := "info-box info-box--no-spacing",
-                    "La préfecture (ou sous-préfecture) ne répondra pas forcément aux questions relative aux renouvellements de titre de séjour ou des certificats d’immatriculation. Pour les titres de séjour concernant les étudiants, vous pouvez utiliser la plateforme du ministère de l’intérieur ",
-                    a(
-                      href := "https://administration-etrangers-en-france.interieur.gouv.fr/particuliers/#/",
-                      target := "_blank",
-                      rel := "noopener",
-                      "à cette adresse"
-                    ),
-                    ". Pour les certificats d’immatriculation, vous pouvez contacter l’ANTS ",
-                    a(
-                      href := "https://ants.gouv.fr/Contacter-l-ANTS/Contactez-nous",
-                      target := "_blank",
-                      rel := "noopener",
-                      "à cette adresse"
-                    ),
-                    "."
-                  )
+              publicNoteBox(
+                frag(
+                  "La préfecture (ou sous-préfecture) ne répondra pas forcément aux questions relative aux renouvellements de titre de séjour ou des certificats d’immatriculation. Pour les titres de séjour concernant les étudiants, vous pouvez utiliser la plateforme du ministère de l’intérieur ",
+                  a(
+                    href := "https://administration-etrangers-en-france.interieur.gouv.fr/particuliers/#/",
+                    target := "_blank",
+                    rel := "noopener",
+                    "à cette adresse"
+                  ),
+                  ". Pour les certificats d’immatriculation, vous pouvez contacter l’ANTS ",
+                  a(
+                    href := "https://ants.gouv.fr/Contacter-l-ANTS/Contactez-nous",
+                    target := "_blank",
+                    rel := "noopener",
+                    "à cette adresse"
+                  ),
+                  "."
                 )
               )
             } else ()

--- a/app/views/showApplication.scala.html
+++ b/app/views/showApplication.scala.html
@@ -621,30 +621,7 @@ dialog {
                                 }
 
                                 @if(groupsThatCanBeInvited.nonEmpty) {
-                                  <fieldset class="single--margin-top-16px mdl-cell mdl-cell--12-col">
-                                    <legend class="single--padding-top-16px single--padding-bottom-16px mdl-typography--title">
-                                      Inviter un organisme sur la discussion
-                                    </legend>
-                                    @for(group <- groupsThatCanBeInvited.sortBy(_.name)) {
-                                    @defining(group.organisationSetOrDeducted) { organisation: Option[Organisation] =>
-                                      <div class="single--padding-top-8px single--padding-bottom-8px single--padding-left-16px">
-                                        <label for="invite-@group.id"
-                                               class="mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect">
-                                          <input id="invite-@group.id"
-                                                 class="mdl-checkbox__input"
-                                                 type="checkbox"
-                                                 name="groups[]"
-                                                 value="@group.id"
-                                          >
-                                          <span class="mdl-checkbox__label">
-                                            <b>@group.name</b>
-                                            @if(organisation.nonEmpty){ <em>(@organisation.get.name)</em> }
-                                          </span>
-                                        </label>
-                                      </div>
-                                    }
-                                    }
-                                  </fieldset>
+                                  @toHtml(views.helpers.applications.inviteTargetGroups(groupsThatCanBeInvited))
                                 }
 
                                 <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label mdl-cell mdl-cell--12-col">

--- a/conf/evolutions/default/46.sql
+++ b/conf/evolutions/default/46.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+ALTER TABLE user_group ADD public_note text NULL;
+
+# --- !Downs
+ALTER TABLE user_group DROP public_note;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -235,6 +235,11 @@ html, body {
     border-left-color: #FF7E47;
 }
 
+.info-box-container {
+    text-align: left;
+    white-space: normal;
+}
+
 .mdl-card__title-text {
     margin-right: 120px;
 }
@@ -710,6 +715,10 @@ a {
     justify-content: center;
 }
 
+.single--height-auto {
+    height: auto !important;
+}
+
 .single--width-100pc {
     width: 100%;
 }
@@ -796,6 +805,10 @@ a {
 
 .single--line-height-24px {
     line-height: 24px !important;
+}
+
+.single--background-color-white {
+    background-color: white;
 }
 
 
@@ -977,4 +990,11 @@ Tabs
     margin-left: 24px;
     margin-right: 24px;
     margin-bottom: 24px;
+}
+
+.form-example {
+    margin-left: 8px;
+    margin-right: 8px;
+    border: 1px solid #9E9E9E;
+    border-radius: 8px;
 }

--- a/test/browser/AnswerSpec.scala
+++ b/test/browser/AnswerSpec.scala
@@ -22,7 +22,8 @@ class AnswerSpec extends Specification with Tables with BaseSpec {
       description = None,
       inseeCode = List("0"),
       creationDate = Time.nowParis(),
-      areaIds = area :: Nil
+      areaIds = area :: Nil,
+      publicNote = None
     )
     groupService.add(group)
     group

--- a/test/browser/ApplicationAccessSpec.scala
+++ b/test/browser/ApplicationAccessSpec.scala
@@ -106,7 +106,8 @@ class ApplicationAccessSpec extends Specification with BaseSpec {
       description = None,
       inseeCode = List("0"),
       creationDate = Time.nowParis(),
-      areaIds = area :: Nil
+      areaIds = area :: Nil,
+      publicNote = None
     )
     groupService.add(instructorGroup)
     val helperGroup = UserGroup(
@@ -115,7 +116,8 @@ class ApplicationAccessSpec extends Specification with BaseSpec {
       description = None,
       inseeCode = List("0"),
       creationDate = Time.nowParis(),
-      areaIds = area :: Nil
+      areaIds = area :: Nil,
+      publicNote = None
     )
     groupService.add(helperGroup)
 

--- a/test/browser/ApplicationSpec.scala
+++ b/test/browser/ApplicationSpec.scala
@@ -31,7 +31,8 @@ class ApplicationSpec extends Specification with BaseSpec {
         description = None,
         inseeCode = List("0"),
         creationDate = Time.nowParis(),
-        areaIds = area :: Nil
+        areaIds = area :: Nil,
+        publicNote = None
       )
       groupService.add(instructorGroup)
       val instructorUser = User(

--- a/test/csv/CSVSpec.scala
+++ b/test/csv/CSVSpec.scala
@@ -71,7 +71,8 @@ class CSVSpec extends Specification {
         creationDate = Time.nowParis(),
         areaIds = List(Area.fromId(UUIDHelper.namedFrom("ardennes"))).flatten.map(_.id),
         organisation = None,
-        email = Some("sip.laon@dgfip.finances.gouv.fr")
+        email = Some("sip.laon@dgfip.finances.gouv.fr"),
+        publicNote = None
       )
 
       val dgfip = data.find(formData => formData.group.name.eqv(expectedUserGroup.name))


### PR DESCRIPTION
* Ajout d'un exemple qui montre l'utilité des descriptions
* Fix `group.description` qui avait été supprimé
* Enlève les attributs `style` sur la liste des groupes
* Refactor de la liste des groupes avec scalatags
* ✅ marche sur IE11

<img width="962" alt="Screen Shot 2021-01-26 at 16 10 38" src="https://user-images.githubusercontent.com/4394842/105864325-19880100-5ff2-11eb-8f40-654edd39847d.png">

<img width="954" alt="Screen Shot 2021-01-26 at 16 11 46" src="https://user-images.githubusercontent.com/4394842/105864353-20167880-5ff2-11eb-8c81-af88eb6dc31b.png">
