### PR TITLE
Mise à jour sentry à la dernière version pour passage à Sentry.io

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,2 +1,1 @@
-updates.ignore = [ { groupId = "io.sentry", artifactId = "sentry-logback" } ]
 updates.pin = [ { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version="x.y." } ]

--- a/build.sbt
+++ b/build.sbt
@@ -112,7 +112,7 @@ libraryDependencies ++= Seq(
   "org.webjars.npm" % "xlsx" % "0.16.9"
 )
 // Crash
-libraryDependencies += "io.sentry" % "sentry-logback" % "1.7.30"
+libraryDependencies += "io.sentry" % "sentry-logback" % "4.3.0"
 
 // Adds additional packages into Twirl
 TwirlKeys.templateImports += "constants.Constants"


### PR DESCRIPTION
Passage sur sentry.io (le compte incubateur)