### PR TITLE
Ajoute un lien vers betagouv dans le footer et améliore la grosseur et contraste

### DIFF
--- a/app/views/home/page.scala.html
+++ b/app/views/home/page.scala.html
@@ -345,13 +345,25 @@
         <footer class="mdl-mega-footer">
             <div class="mdl-mega-footer__middle-section">
                 <div class="mdl-mega-footer__drop-down-section">
-                    <span>Un service fourni par la DINUM</span><br />
                     <img
                     class="footer__logo"
                     src="@routes.Assets.versioned("images/logo_dinum_150x202.png")"
                     alt="Administration+"
-                    /><br />
-                    <h3 class="mdl-color-text--white">beta.gouv.fr</h3>
+                    />
+                    <br />
+                    <span>Un service fourni par la DINUM</span>
+                </div>
+
+                <div class="mdl-mega-footer__drop-down-section">
+                    <ul class="mdl-mega-footer__link-list">
+                      <li>
+                        <img src='@routes.Assets.versioned("images/logo_small_150x160.png")' class="logo-header" alt="logo Administration+"><span class="mdl-mega-footer__aplus">Administration+</span>
+                      </li>
+                      <li>
+                        <a href="https://beta.gouv.fr/startups/aplus"
+                           class="mdl-mega-footer__beta-link">Une startup d’État de beta.gouv</a>
+                      </li>
+                    </ul>
                 </div>
 
                 <div class="mdl-mega-footer__drop-down-section">

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -125,6 +125,47 @@ html, body {
     padding-bottom: 4px;
 }
 
+.mdl-mega-footer {
+    color: #fff;
+    background-color: #1c1c1c;
+    font-size: 16px;
+    font-weight: 400;
+}
+
+.mdl-mega-footer__middle-section {
+    display: flex;
+    justify-content: space-between;
+}
+
+.mdl-mega-footer__aplus {
+    font-size: 20px;
+    margin-left: 16px;
+}
+
+.mdl-mega-footer__beta-link {
+    margin-left: 63px;
+}
+
+.mdl-mega-footer a {
+    color: #fff;
+    font-size: 16px;
+    font-weight: 400;
+}
+
+.mdl-mega-footer li {
+    color: #fff;
+    font-size: 16px;
+    font-weight: 400;
+    margin-top: 8px;
+    margin-bottom: 8px !important;
+}
+
+.mdl-mega-footer .mdl-logo {
+    margin-top: 8px;
+    margin-bottom: 8px;
+    margin-right: 32px;
+}
+
 .mdl-card__supporting-text {
     width: 100% !important;
     box-sizing: border-box;


### PR DESCRIPTION
Homepage
<img width="1163" alt="Screen Shot 2021-04-28 at 17 50 05" src="https://user-images.githubusercontent.com/4394842/116434155-75109780-a84a-11eb-8bc8-e8fa46fbd781.png">

Autres
<img width="1004" alt="Screen Shot 2021-04-28 at 17 50 11" src="https://user-images.githubusercontent.com/4394842/116434161-76da5b00-a84a-11eb-806c-e9b7e76e6dc9.png">
