### PR TITLE
Corrige l’affichage de l’année des janviers shiftée de +1

### DIFF
--- a/app/helper/Time.scala
+++ b/app/helper/Time.scala
@@ -22,8 +22,9 @@ object Time {
   def formatPatternFr(date: LocalDate, pattern: String): String =
     date.format(DateTimeFormatter.ofPattern(pattern, Locale.FRANCE))
 
+  // Note that .atDay(1) will yield incorrect format value
   def formatMonthYearAllLetters(month: YearMonth): String =
-    month.atDay(1).format(monthYearAllLettersFormatter)
+    month.atDay(15).format(monthYearAllLettersFormatter)
 
   val adminsFormatter = DateTimeFormatter.ofPattern("dd/MM/YY-HH:mm", Locale.FRANCE)
   private val monthYearAllLettersFormatter = DateTimeFormatter.ofPattern("MMMM YYYY", Locale.FRANCE)


### PR DESCRIPTION
<img width="989" alt="Screen Shot 2022-02-15 at 11 30 36" src="https://user-images.githubusercontent.com/4394842/154043853-ef67f97c-205b-46e7-b7d3-8b4cac8cd8d7.png">
