### PR TITLE
Utilise le dsfr sur les pages d’erreur par défaut 404, 500 et 503

### DIFF
--- a/app/playutils/ErrorHandler.scala
+++ b/app/playutils/ErrorHandler.scala
@@ -1,0 +1,49 @@
+package playutils
+
+import helper.ScalatagsHelpers.writeableOf_Modifier
+import javax.inject.{Inject, Provider, Singleton}
+import play.api.{Configuration, Environment, Mode, OptionalSourceMapper, UsefulException}
+import play.api.http.DefaultHttpErrorHandler
+import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.Results.{InternalServerError, NotFound, ServiceUnavailable}
+import play.api.routing.Router
+import scala.concurrent.Future
+
+@Singleton
+class ErrorHandler @Inject() (
+    env: Environment,
+    config: Configuration,
+    sourceMapper: OptionalSourceMapper,
+    router: Provider[Router]
+) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+
+  override def onNotFound(request: RequestHeader, message: String): Future[Result] =
+    Future.successful {
+      if (env.mode == Mode.Dev) {
+        // From https://github.com/playframework/playframework/blob/3.0.1/core/play/src/main/scala/play/api/http/HttpErrorHandler.scala#L230
+        NotFound(
+          views.html.defaultpages.devNotFound(request.method, request.uri, Some(router.get()))(
+            request
+          )
+        )
+      } else {
+        NotFound(views.errors.public404())
+      }
+    }
+
+  override def onProdServerError(request: RequestHeader, exception: UsefulException) =
+    Future.successful {
+      serverError(request, exception)
+    }
+
+  private def serverError(request: RequestHeader, exception: UsefulException): Result = {
+    val isTransient = exception.cause.isInstanceOf[java.sql.SQLTransientConnectionException]
+    val result =
+      if (isTransient)
+        ServiceUnavailable(views.errors.public503())
+      else
+        InternalServerError(views.errors.public500(Some(exception.id)))
+    result
+  }
+
+}

--- a/app/views/errors.scala
+++ b/app/views/errors.scala
@@ -7,59 +7,100 @@ import constants.Constants
 object errors {
 
   def public403(): Tag =
-    views.main.publicLayout(
-      "Accès non autorisé - Administration+",
-      public403Main(),
-      addBreadcrumbs = false,
+    publicError(
+      headTitle = "Accès non autorisé - Administration+",
+      h1Title = "Accès non autorisé",
+      errorCode = "Erreur 403",
+      apologyMessage =
+        "Il semblerait que vous ayez tenté d’accéder à une partie sécurisée du site pour laquelle vous ne disposez pas des autorisations nécessaires.",
+      helpMessage = frag(
+        "Si vous pensez qu’il s’agit d’une omission, vous pouvez contacter le support Administration+ à l’adresse ",
+        Constants.supportEmail,
+        "."
+      ),
     )
 
-  private def public403Main(): Tag =
-    div(cls := "fr-container")(
-      div(
-        cls := "fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center"
-      )(
-        div(cls := "fr-py-0 fr-col-12 fr-col-md-6")(
-          h1("Accès non autorisé"),
-          p(cls := "fr-text--sm fr-mb-3w")("Erreur 403"),
-          p(cls := "fr-text--sm fr-mb-5w")(
-            "Il semblerait que vous ayez tenté d’accéder à une partie sécurisée du site pour laquelle vous ne disposez pas des autorisations nécessaires.",
-          ),
-          p(cls := "fr-text--lead fr-mb-3w")(
-            "Si vous pensez qu’il s’agit d’une omission, vous pouvez contacter le support Administration+ à l’adresse ",
-            Constants.supportEmail,
-            "."
-          ),
-        )
+  def public404(): Tag =
+    publicError(
+      headTitle = "Page non trouvée - Administration+",
+      h1Title = "Page non trouvée",
+      errorCode = "Erreur 404",
+      apologyMessage =
+        "La page que vous cherchez est introuvable. Excusez-nous pour la gène occasionnée.",
+      helpMessage = frag(
+        "Si vous avez tapé l'adresse web dans le navigateur, vérifiez qu'elle est correcte. La page n’est peut-être plus disponible. ",
+        br,
+        "Dans ce cas, pour continuer votre visite vous pouvez consulter notre page d’accueil.",
+        br,
+        "Sinon contactez le support Administration+ à l’adresse ",
+        Constants.supportEmail,
+        " pour que l’on puisse vous rediriger vers la bonne information."
+      ),
+      additionalElements = ul(cls := "fr-btns-group fr-btns-group--inline-md")(
+        li(a(cls := "fr-btn", href := "/")("Page d'accueil"))
       )
     )
 
-  def public500(): Tag =
-    views.main.publicLayout(
-      "Erreur inattendue - Administration+",
-      public500Main(),
-      addBreadcrumbs = false,
+  def public500(publicErrorCode: Option[String] = None): Tag =
+    publicError(
+      headTitle = "Erreur inattendue - Administration+",
+      h1Title = "Erreur inattendue",
+      errorCode = "Erreur 500",
+      apologyMessage =
+        "Désolé, le service rencontre un problème. Celui-ci est probablement temporaire. ",
+      helpMessage = frag(
+        "Essayez de rafraîchir la page, sinon merci de réessayer plus tard. ",
+        "Si le problème venait à persister, vous pouvez contacter le support Administration+ à l’adresse ",
+        Constants.supportEmail,
+        publicErrorCode.map(code =>
+          frag(
+            " en fournissant le code d’erreur ",
+            b(code),
+          )
+        ),
+        "."
+      ),
     )
 
-  private def public500Main(): Tag =
-    div(cls := "fr-container")(
-      div(
-        cls := "fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center"
-      )(
-        div(cls := "fr-py-0 fr-col-12 fr-col-md-6")(
-          h1("Erreur inattendue"),
-          p(cls := "fr-text--sm fr-mb-3w")("Erreur 500"),
-          p(cls := "fr-text--sm fr-mb-5w")(
-            "Désolé, le service rencontre un problème. ",
-            "Celui-ci est probablement temporaire. ",
-          ),
-          p(cls := "fr-text--lead fr-mb-3w")(
-            "Essayez de rafraîchir la page, sinon merci de réessayer plus tard. ",
-            "Si le problème venait à persister, vous pouvez contacter le support Administration+ à l’adresse ",
-            Constants.supportEmail,
-            "."
-          ),
+  def public503(): Tag =
+    publicError(
+      headTitle = "Service indisponible - Administration+",
+      h1Title = "Service indisponible",
+      errorCode = "Erreur 503",
+      apologyMessage =
+        "Le service Administration+ rencontre un problème, nous travaillons pour le résoudre le plus rapidement possible. ",
+      helpMessage = frag(
+        "Merci de réessayer plus tard. Vous serez bientôt en mesure de réutiliser le service. ",
+        "Si le problème venait à persister, vous pouvez contacter le support Administration+ à l’adresse ",
+        Constants.supportEmail,
+        "."
+      ),
+    )
+
+  private def publicError(
+      headTitle: String,
+      h1Title: String,
+      errorCode: String,
+      apologyMessage: Frag,
+      helpMessage: Frag,
+      additionalElements: Frag = frag(),
+  ): Tag =
+    views.main.publicLayout(
+      headTitle,
+      div(cls := "fr-container")(
+        div(
+          cls := "fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center"
+        )(
+          div(cls := "fr-py-0 fr-col-12 fr-col-md-6")(
+            h1(h1Title),
+            p(cls := "fr-text--sm fr-mb-3w")(errorCode),
+            p(cls := "fr-text--lead fr-mb-3w")(apologyMessage),
+            p(cls := "fr-text--sm fr-mb-5w")(helpMessage),
+            additionalElements
+          )
         )
-      )
+      ),
+      addBreadcrumbs = false,
     )
 
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,6 +13,7 @@ play.modules.enabled += "tasks.RemoveExpiredFilesModule"
 play.modules.enabled += "tasks.ViewsRefreshTaskModule"
 play.modules.enabled += "tasks.WeeklyEmailsModule"
 play.modules.enabled += "tasks.WipeOldDataModule"
+play.http.errorHandler = "playutils.ErrorHandler"
 
 ### Forms
 play.http.parser.maxMemoryBuffer = 1M // needed for CSV form only


### PR DESCRIPTION
Page 404 (page par défaut)
<img width="1048" alt="Screenshot 2024-02-26 at 14 32 02" src="https://github.com/betagouv/aplus/assets/4394842/2979980c-1320-4a5f-b310-7bdf51d3e003">

Page 503 en cas de timeout de la connexion à la BDD
<img width="1229" alt="Screenshot 2024-02-26 at 14 33 31" src="https://github.com/betagouv/aplus/assets/4394842/9cbee2d6-0b4d-4756-aaa3-004a49cb9bf8">

Page 500
<img width="1249" alt="Screenshot 2024-02-26 at 14 35 51" src="https://github.com/betagouv/aplus/assets/4394842/7206ed58-17f8-4f80-98cb-321c82f23281">
