### PR TITLE
Ajoute le fait qu’un opérateur a traité la demande

### DIFF
--- a/app/views/application.scala
+++ b/app/views/application.scala
@@ -346,12 +346,16 @@ object application {
                   application.creatorUserId === currentUser.id &&
                   !application.closed &&
                   (answer.creatorUserID =!= currentUser.id)
+              val showGenericApplicationProcessed =
+                answer.answerType === Answer.AnswerType.ApplicationProcessed &&
+                  !showArchiveButton
               val messageHasInfos =
                 // Note: always true for admins "** Message de 0 caractères **"
                 answer.message.nonEmpty ||
                   answer.declareApplicationHasIrrelevant ||
                   answer.userInfos.getOrElse(Map.empty).nonEmpty ||
-                  showArchiveButton
+                  showArchiveButton ||
+                  showGenericApplicationProcessed
               frag(
                 answerFilesLinks(
                   attachments,
@@ -475,7 +479,16 @@ object application {
                               br,
                               br
                             )
-                          )
+                          ),
+                        showGenericApplicationProcessed.some
+                          .filter(identity)
+                          .map(_ =>
+                            div(
+                              cls := "info-box",
+                              answer.creatorUserName,
+                              " a indiqué avoir traité la demande.",
+                            )
+                          ),
                       )
                     )
                   )


### PR DESCRIPTION
<img width="798" alt="Screenshot 2024-08-28 at 11 37 09" src="https://github.com/user-attachments/assets/ae9da702-7551-4678-b500-3a478f813ed9">
