### PR TITLE
Ajoute de l’espace entre le nom et la description du groupe

### DIFF
--- a/app/views/editMyGroups.scala
+++ b/app/views/editMyGroups.scala
@@ -102,7 +102,7 @@ object editMyGroups {
           } else {
             group.name
           },
-          span(cls := "text--font-size-medium", group.description)
+          span(cls := "text--font-size-medium single--margin-left-8px", group.description)
         )
       ),
       table(


### PR DESCRIPTION
<img width="969" alt="Screenshot 2024-12-02 at 09 36 27" src="https://github.com/user-attachments/assets/b46415a0-a419-4527-ac01-4213e5b37d26">
